### PR TITLE
Implement Polygon data backend for daily screen

### DIFF
--- a/.github/workflows/daily_screen.yml
+++ b/.github/workflows/daily_screen.yml
@@ -1,0 +1,34 @@
+name: Daily -40 Drop Screen
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 3 * * 2-6'
+
+jobs:
+  run-screen:
+    runs-on: ubuntu-latest
+    env:
+      NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+      NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+      DATA_API_KEY: ${{ secrets.DATA_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Prepare run directory
+        run: mkdir -p runs
+      - name: Run screen
+        run: |
+          python main.py --run
+      - name: Upload run log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: run-log
+          path: runs

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+runs/
+charts/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# Value-Stocks
+# Daily −40% Drop Value Screen
+
+This project generates a daily Notion report of U.S. value stocks that suffered a large price drawdown. The workflow:
+
+1. Pulls candidates from the configured market data provider (Polygon by default, with a deterministic sample fallback).
+2. Applies drop-trigger and survivability filters.
+3. Scores candidates across valuation, quality, momentum, risk and liquidity components.
+4. Renders charts/background blurbs and pushes the ranked table plus risk rules to Notion.
+5. Stores a deterministic JSON run-log per day.
+
+## Requirements
+
+* Python 3.11+
+* (Optional) `pip install -r requirements.txt` for third-party helpers such as `requests`
+* Notion API credentials and a database to host the daily report
+* API key for the chosen data provider (Polygon is assumed in the sample config)
+
+## Configuration
+
+Runtime settings live in `config.yaml`. You can adjust:
+
+* Execution parameters – time zone, max candidates, directories.
+* Universe filters – minimum price, market cap and sector caps.
+* Hard filters – cash flow, leverage and earnings windows.
+* Scoring weights – tweak each bucket or penalty without touching code.
+
+## Environment variables
+
+Create a `.env` file with:
+
+```
+NOTION_API_KEY=secret_token
+NOTION_DATABASE_ID=database_uuid
+DATA_API_KEY=polygon_or_other_key
+```
+
+If `DATA_API_KEY` is omitted, the pipeline uses a deterministic sample backend to make dry runs reproducible.
+
+## Running locally
+
+```
+python main.py --run --dry-run       # Executes without pushing to Notion
+python main.py --run                 # Full run (requires env vars)
+python main.py --run --date 2024-05-01
+```
+
+Each run writes a summary to `runs/YYYY-MM-DD.json` and saves charts under `charts/`.
+
+## Tests
+
+```
+pytest
+```
+
+Unit coverage focuses on the scoring engine and hard filters.
+
+## GitHub Actions
+
+The workflow `.github/workflows/daily_screen.yml` executes `python main.py --run` every weekday at 23:00 America/New_York and supports manual dispatch. The job publishes the run-log as an artifact for traceability.
+
+## Notion setup notes
+
+The script treats `NOTION_DATABASE_ID` as the database receiving the daily page. Ensure it has a **title** property named `Ticker`. The script creates/updates a page titled `Daily −40% Drop Value Screen – YYYY-MM-DD` and appends the summary blocks, table, five-year toggles and rules. Re-running the same day archives the prior blocks before appending fresh content for idempotency.
+
+## Adjusting weights
+
+Update `config.yaml` under the `scores` section. The total score rescales automatically to 0–100 regardless of bucket weights, so you can experiment with different emphasis without rewriting the code.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,61 @@
+# Configuration for Daily -40% Drop Value Screen
+execution:
+  max_candidates: 12
+  min_candidates_before_expand: 5
+  expanded_drawdown_threshold: -0.04
+  log_dir: runs
+  chart_dir: charts
+  timezone: America/New_York
+  market_close_hour: 16
+  market_close_minute: 0
+
+data_source:
+  provider: polygon
+  base_url: https://api.polygon.io
+  max_retries: 5
+  backoff_seconds: 1
+  cache_ttl_seconds: 900
+
+universe:
+  exchanges: [NYSE, NASDAQ, AMEX]
+  min_price: 3.0
+  min_market_cap: 500000000
+  min_adv_usd: 5000000
+  max_total_candidates: 25
+  max_per_sector: 5
+  excluded_keywords: ["ETF", "ETN", "SPAC"]
+
+filters:
+  min_gross_margin: 0.15
+  allow_low_margin_sectors: [Energy, Materials]
+  min_interest_coverage: 3.0
+  max_net_debt_ebitda: 4.0
+  earnings_days_buffer: 2
+  earnings_window_days: 10
+  flagged_headline_window_days: 3
+
+scores:
+  valuation:
+    fcf_yield_weight: 15
+    ev_to_ebitda_weight: 10
+    price_to_book_weight: 5
+  quality:
+    roic_weight: 10
+    gross_margin_stability_weight: 5
+    revenue_cagr_weight: 5
+  momentum:
+    rsi_weight: 10
+    distance_to_200dma_weight: 5
+  risk:
+    beta_band_center: 1.0
+    beta_band_halfwidth: 0.4
+    beta_weight: 10
+    volatility_weight: 5
+  liquidity:
+    dollar_volume_weight: 5
+    short_interest_weight: 5
+  penalties:
+    earnings_weight: 10
+    headline_weight: 25
+    sec_delinquency_weight: 40
+    going_concern_weight: 60

--- a/main.py
+++ b/main.py
@@ -1,0 +1,78 @@
+"""Entry point for the Daily −40% Drop Value Screen."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+from value_stocks.config_loader import load_config
+from value_stocks.report import create_runner
+from value_stocks.utils import setup_logger
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Daily −40% Drop Value Screen")
+    parser.add_argument("--run", action="store_true", help="Execute the pipeline")
+    parser.add_argument("--dry-run", action="store_true", help="Do not push to Notion")
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=None,
+        help="Override run date in YYYY-MM-DD (for testing)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logger = setup_logger("value_stocks.main")
+    if not args.run:
+        logger.error("Use --run to execute the screen")
+        return 1
+
+    _load_env_file()
+    env = {
+        "NOTION_API_KEY": os.getenv("NOTION_API_KEY"),
+        "NOTION_DATABASE_ID": os.getenv("NOTION_DATABASE_ID"),
+        "DATA_API_KEY": os.getenv("DATA_API_KEY"),
+    }
+    config = load_config("config.yaml")
+    runner = create_runner(config, env)
+    run_date = None
+    if args.date:
+        try:
+            run_date = datetime.fromisoformat(args.date).date()
+        except ValueError as exc:
+            logger.error("Invalid --date value: %s", exc)
+            return 1
+    try:
+        metadata = runner.run(run_date=run_date, dry_run=args.dry_run)
+    except Exception as exc:  # pragma: no cover - top-level guard
+        logger.exception("Pipeline failed: %s", exc)
+        return 1
+    logger.info(
+        "Completed run: %s candidates considered, %s passed",
+        metadata.considered,
+        metadata.passed_filters,
+    )
+    return 0
+
+
+def _load_env_file(path: str = ".env") -> None:
+    if not os.path.exists(path):
+        return
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            if key and value:
+                os.environ.setdefault(key.strip(), value.strip())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+pytest>=8.0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,85 @@
+"""Unit tests for filters."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from value_stocks.filters import determine_drop_trigger, passes_value_filters
+from value_stocks.models import CandidateMetrics, FiveYearStats
+
+
+def _baseline_metrics() -> CandidateMetrics:
+    return CandidateMetrics(
+        ticker="AAA",
+        company_name="Test Co",
+        sector="Industrials",
+        industry="Tools",
+        market_cap=1_000_000_000,
+        price=25.0,
+        open_price=26.0,
+        high_price=27.0,
+        low_price=24.0,
+        change_1d=-0.45,
+        change_5d=-0.12,
+        change_1m=-0.2,
+        change_6m=-0.3,
+        change_1y=-0.5,
+        change_5y=0.1,
+        distance_from_52w_high=-0.5,
+        distance_from_200dma=-0.2,
+        percent_to_200dma=0.2,
+        rsi_14=25.0,
+        beta=1.0,
+        realized_vol_30d=0.4,
+        short_interest_percent=0.06,
+        avg_dollar_volume=6_000_000,
+        shares_outstanding_trend=0.0,
+        free_cash_flow_yield=0.12,
+        ev_to_ebitda=6.0,
+        pe_ratio=11.0,
+        pb_ratio=1.1,
+        ps_ratio=2.2,
+        gross_margin=0.4,
+        gross_margin_stability=0.05,
+        operating_margin=0.2,
+        revenue_cagr_3y=0.1,
+        roic=0.12,
+        net_debt_to_ebitda=1.5,
+        interest_coverage=6.0,
+        operating_cash_flow_positive=True,
+        insider_net_buy_percent=0.01,
+        earnings_date=date.today() + timedelta(days=15),
+        last_earnings_date=date.today() - timedelta(days=90),
+        headline_flags=[],
+        sec_delinquent=False,
+        going_concern=False,
+        trading_halted=False,
+        price_history_5y=[],
+        five_year_stats=FiveYearStats(),
+    )
+
+
+def test_determine_drop_trigger_single_day() -> None:
+    metrics = _baseline_metrics()
+    passed, trigger, reasons = determine_drop_trigger(metrics, expanded=False)
+    assert passed
+    assert trigger == "1-day −40%"
+    assert reasons
+
+
+def test_value_filter_rejects_high_leverage() -> None:
+    metrics = _baseline_metrics()
+    metrics.net_debt_to_ebitda = 5.0
+    result = passes_value_filters(
+        metrics,
+        {
+            "max_net_debt_ebitda": 4,
+            "min_interest_coverage": 3,
+            "min_gross_margin": 0.15,
+            "allow_low_margin_sectors": [],
+            "earnings_days_buffer": 2,
+            "flagged_headline_window_days": 3,
+        },
+        date.today(),
+    )
+    assert not result.passed
+    assert any("Net debt" in reason for reason in result.reasons)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,88 @@
+"""Unit tests for scoring."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from value_stocks.models import CandidateMetrics, FiveYearStats
+from value_stocks.scoring import calculate_scores
+
+
+def _make_metrics(ticker: str, fcf: float, earnings_offset: int = 20) -> CandidateMetrics:
+    return CandidateMetrics(
+        ticker=ticker,
+        company_name="Test Co",
+        sector="Industrials",
+        industry="Tools",
+        market_cap=1_000_000_000,
+        price=25.0,
+        open_price=26.0,
+        high_price=27.0,
+        low_price=24.0,
+        change_1d=-0.42,
+        change_5d=-0.1,
+        change_1m=-0.2,
+        change_6m=-0.3,
+        change_1y=-0.5,
+        change_5y=0.2,
+        distance_from_52w_high=-0.45,
+        distance_from_200dma=-0.2,
+        percent_to_200dma=0.2,
+        rsi_14=25.0,
+        beta=1.1,
+        realized_vol_30d=0.45,
+        short_interest_percent=0.05,
+        avg_dollar_volume=10_000_000,
+        shares_outstanding_trend=-0.01,
+        free_cash_flow_yield=fcf,
+        ev_to_ebitda=5.0,
+        pe_ratio=10.0,
+        pb_ratio=1.0,
+        ps_ratio=2.0,
+        gross_margin=0.35,
+        gross_margin_stability=0.05,
+        operating_margin=0.18,
+        revenue_cagr_3y=0.12,
+        roic=0.11,
+        net_debt_to_ebitda=1.0,
+        interest_coverage=5.0,
+        operating_cash_flow_positive=True,
+        insider_net_buy_percent=0.02,
+        earnings_date=date.today() + timedelta(days=earnings_offset),
+        last_earnings_date=date.today() - timedelta(days=90),
+        headline_flags=[],
+        sec_delinquent=False,
+        going_concern=False,
+        trading_halted=False,
+        price_history_5y=[],
+        five_year_stats=FiveYearStats(),
+    )
+
+
+def test_higher_fcf_yield_scores_better() -> None:
+    metrics_a = _make_metrics("AAA", 0.15)
+    metrics_b = _make_metrics("BBB", 0.05)
+    config = {
+        "valuation": {"fcf_yield_weight": 15, "ev_to_ebitda_weight": 10, "price_to_book_weight": 5},
+        "quality": {"roic_weight": 10, "gross_margin_stability_weight": 5, "revenue_cagr_weight": 5},
+        "momentum": {"rsi_weight": 10, "distance_to_200dma_weight": 5},
+        "risk": {"beta_weight": 10, "beta_band_center": 1.0, "beta_band_halfwidth": 0.4, "volatility_weight": 5},
+        "liquidity": {"dollar_volume_weight": 5, "short_interest_weight": 5},
+        "penalties": {"earnings_weight": 10, "headline_weight": 25, "sec_delinquency_weight": 40, "going_concern_weight": 60},
+    }
+    scores = calculate_scores([metrics_a, metrics_b], config, date.today())
+    assert scores["AAA"].total > scores["BBB"].total
+
+
+def test_earnings_penalty_applied() -> None:
+    metrics_safe = _make_metrics("SAFE", 0.12, earnings_offset=30)
+    metrics_near = _make_metrics("NEAR", 0.12, earnings_offset=3)
+    config = {
+        "valuation": {"fcf_yield_weight": 15, "ev_to_ebitda_weight": 10, "price_to_book_weight": 5},
+        "quality": {"roic_weight": 10, "gross_margin_stability_weight": 5, "revenue_cagr_weight": 5},
+        "momentum": {"rsi_weight": 10, "distance_to_200dma_weight": 5},
+        "risk": {"beta_weight": 10, "beta_band_center": 1.0, "beta_band_halfwidth": 0.4, "volatility_weight": 5},
+        "liquidity": {"dollar_volume_weight": 5, "short_interest_weight": 5},
+        "penalties": {"earnings_weight": 10, "headline_weight": 25, "sec_delinquency_weight": 40, "going_concern_weight": 60},
+    }
+    scores = calculate_scores([metrics_safe, metrics_near], config, date.today())
+    assert scores["SAFE"].total > scores["NEAR"].total

--- a/value_stocks/__init__.py
+++ b/value_stocks/__init__.py
@@ -1,0 +1,13 @@
+"""Value Stocks daily screen package."""
+
+__all__ = [
+    "config",
+    "models",
+    "data_provider",
+    "filters",
+    "scoring",
+    "notion",
+    "report",
+    "charts",
+    "background",
+]

--- a/value_stocks/background.py
+++ b/value_stocks/background.py
@@ -1,0 +1,53 @@
+"""Generate contextual blurbs for candidates."""
+from __future__ import annotations
+
+from datetime import date
+from typing import List
+
+from .models import CandidateMetrics
+from .utils import format_percent
+
+
+def build_background_blurb(metrics: CandidateMetrics, run_date: date) -> str:
+    """Create a concise multi-sentence background string."""
+
+    sentences: List[str] = []
+    sentences.append(
+        f"{metrics.company_name} ({metrics.ticker}) operates in the {metrics.industry.lower()} space within {metrics.sector}."
+    )
+    if metrics.triggered_conditions:
+        sentences.append(
+            "The stock qualified due to "
+            + ", ".join(metrics.triggered_conditions)
+            + "."
+        )
+    if metrics.free_cash_flow_yield is not None and metrics.five_year_stats.median_pe:
+        sentences.append(
+            "Valuation screens attractive with FCF yield "
+            f"{format_percent(metrics.free_cash_flow_yield)} and P/E {metrics.pe_ratio:.1f} "
+            f"vs 5Y median {metrics.five_year_stats.median_pe:.1f}."
+        )
+    if metrics.revenue_cagr_3y is not None and metrics.roic is not None:
+        sentences.append(
+            "Fundamentals show {growth} revenue CAGR and ROIC {roic}.".format(
+                growth=format_percent(metrics.revenue_cagr_3y),
+                roic=format_percent(metrics.roic),
+            )
+        )
+    risk_parts: List[str] = []
+    if metrics.beta is not None:
+        risk_parts.append(f"beta {metrics.beta:.2f}")
+    if metrics.realized_vol_30d is not None:
+        risk_parts.append(f"30d vol {format_percent(metrics.realized_vol_30d)}")
+    if metrics.short_interest_percent is not None:
+        risk_parts.append(f"short interest {format_percent(metrics.short_interest_percent)}")
+    if risk_parts:
+        sentences.append("Risk check: " + ", ".join(risk_parts) + ".")
+    if metrics.headline_flags:
+        sentences.append(
+            "Watch headlines: " + ", ".join(metrics.headline_flags) + "."
+        )
+    sentences.append(
+        "Key risks include execution on turn-around and maintaining liquidity buffers."
+    )
+    return " ".join(sentences)

--- a/value_stocks/charts.py
+++ b/value_stocks/charts.py
@@ -1,0 +1,65 @@
+"""Chart generation utilities using only the standard library."""
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+from typing import Sequence
+
+from .models import PricePoint
+from .utils import ensure_dir
+
+
+def generate_price_chart(
+    ticker: str, history: Sequence[PricePoint], output_dir: str | Path
+) -> Path:
+    """Render a minimalist PNG line chart for the last five years."""
+
+    ensure_dir(output_dir)
+    path = Path(output_dir) / f"{ticker}_5y.png"
+    width, height = 640, 320
+    pixels = [255, 255, 255] * width * height
+
+    if history:
+        closes = [point.close for point in history]
+        min_price = min(closes)
+        max_price = max(closes)
+        price_range = max(max_price - min_price, 1e-6)
+        step = max(1, len(closes) // width)
+        sampled = closes[-width * step :]
+        points = [sampled[i] for i in range(0, len(sampled), step)]
+        if len(points) < width:
+            pad = [points[-1]] * (width - len(points))
+            points.extend(pad)
+        for x, price in enumerate(points[:width]):
+            norm = (price - min_price) / price_range
+            y = height - 20 - int(norm * (height - 40))
+            for dy in range(-1, 2):
+                yy = max(0, min(height - 1, y + dy))
+                idx = (yy * width + x) * 3
+                pixels[idx : idx + 3] = [31, 119, 180]
+
+    _write_png(path, width, height, pixels)
+    return path
+
+
+def _write_png(path: Path, width: int, height: int, pixels: Sequence[int]) -> None:
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    raw_rows = []
+    for y in range(height):
+        start = y * width * 3
+        end = start + width * 3
+        raw_rows.append(b"\x00" + bytes(pixels[start:end]))
+    compressed = zlib.compress(b"".join(raw_rows), level=9)
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    png_bytes = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header) + chunk(b"IDAT", compressed) + chunk(b"IEND", b"")
+    with path.open("wb") as handle:
+        handle.write(png_bytes)

--- a/value_stocks/config_loader.py
+++ b/value_stocks/config_loader.py
@@ -1,0 +1,82 @@
+"""Configuration loading utilities without external YAML deps."""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+@dataclass
+class AppConfig:
+    """Container for configuration values."""
+
+    raw: Dict[str, Any]
+
+    @property
+    def execution(self) -> Dict[str, Any]:
+        return self.raw.get("execution", {})
+
+    @property
+    def data_source(self) -> Dict[str, Any]:
+        return self.raw.get("data_source", {})
+
+    @property
+    def universe(self) -> Dict[str, Any]:
+        return self.raw.get("universe", {})
+
+    @property
+    def filters(self) -> Dict[str, Any]:
+        return self.raw.get("filters", {})
+
+    @property
+    def scores(self) -> Dict[str, Any]:
+        return self.raw.get("scores", {})
+
+
+def load_config(path: str | Path) -> AppConfig:
+    """Load configuration from a small YAML subset."""
+    with Path(path).expanduser().open("r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+    raw = _parse_simple_yaml(lines)
+    return AppConfig(raw=raw)
+
+
+def _parse_simple_yaml(lines: List[str]) -> Dict[str, Any]:
+    root: Dict[str, Any] = {}
+    stack: List[Tuple[int, Dict[str, Any]]] = [(0, root)]
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        key, _, value = line.lstrip().partition(":")
+        key = key.strip()
+        value = value.strip()
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+        current = stack[-1][1]
+        if value == "":
+            new_dict: Dict[str, Any] = {}
+            current[key] = new_dict
+            stack.append((indent + 2, new_dict))
+            continue
+        current[key] = _convert_scalar(value)
+    return root
+
+
+def _convert_scalar(value: str) -> Any:
+    if value.startswith("[") and value.endswith("]"):
+        try:
+            return ast.literal_eval(value)
+        except Exception:  # pragma: no cover
+            return value
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value.strip('"\'')

--- a/value_stocks/data_provider.py
+++ b/value_stocks/data_provider.py
@@ -1,0 +1,1061 @@
+"""Market data provider implementations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import math
+import random
+import statistics
+import time
+
+from .models import CandidateMetrics, FiveYearStats, PricePoint
+from .utils import in_memory_cache, retry_with_backoff, setup_logger
+
+
+def _percent_change(points: Sequence[PricePoint], periods: int) -> Optional[float]:
+    if periods <= 0 or len(points) <= periods:
+        return None
+    end = points[-1].close
+    start = points[-(periods + 1)].close
+    if start == 0:
+        return None
+    return (end - start) / start
+
+
+def _distance_from_high(points: Sequence[PricePoint], periods: int) -> Optional[float]:
+    if not points:
+        return None
+    window = points[-(periods + 1) :] if len(points) > periods else points
+    high = max(point.close for point in window)
+    if high == 0:
+        return None
+    return (points[-1].close - high) / high
+
+
+def _moving_average(points: Sequence[PricePoint], window: int) -> Optional[float]:
+    if len(points) < window or window <= 0:
+        return None
+    subset = points[-window:]
+    total = sum(point.close for point in subset)
+    return total / window
+
+
+def _distance_from_moving_average(points: Sequence[PricePoint], window: int) -> Tuple[Optional[float], Optional[float]]:
+    ma = _moving_average(points, window)
+    if ma is None or ma == 0:
+        return None, None
+    last = points[-1].close
+    return (last - ma) / ma, abs(last - ma) / ma
+
+
+def _compute_rsi_from_window(window: Sequence[float]) -> Optional[float]:
+    if len(window) <= 1:
+        return None
+    gains = 0.0
+    losses = 0.0
+    for idx in range(1, len(window)):
+        change = window[idx] - window[idx - 1]
+        if change >= 0:
+            gains += change
+        else:
+            losses += -change
+    period = len(window) - 1
+    avg_gain = gains / period
+    avg_loss = losses / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+def _calculate_rsi(points: Sequence[PricePoint], period: int = 14) -> Optional[float]:
+    if len(points) <= period:
+        return None
+    window = [point.close for point in points[-(period + 1) :]]
+    return _compute_rsi_from_window(window)
+
+
+def _daily_returns(points: Sequence[PricePoint]) -> List[float]:
+    returns: List[float] = []
+    for idx in range(1, len(points)):
+        prev = points[idx - 1].close
+        curr = points[idx].close
+        if prev <= 0:
+            continue
+        returns.append((curr - prev) / prev)
+    return returns
+
+
+def _calculate_realized_vol(points: Sequence[PricePoint], window: int = 30) -> Optional[float]:
+    if len(points) <= window:
+        return None
+    returns = _daily_returns(points[-(window + 1) :])
+    if len(returns) < 2:
+        return None
+    mean = sum(returns) / len(returns)
+    variance = sum((value - mean) ** 2 for value in returns) / (len(returns) - 1)
+    return math.sqrt(variance) * math.sqrt(252)
+
+
+def _calculate_avg_dollar_volume(points: Sequence[PricePoint], window: int = 30) -> Optional[float]:
+    if not points:
+        return None
+    subset = points[-window:] if len(points) >= window else points
+    values = [point.close * point.volume for point in subset if point.volume]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _calculate_beta(
+    asset_points: Sequence[PricePoint], market_points: Sequence[PricePoint]
+) -> Optional[float]:
+    asset_returns = _daily_returns(asset_points)
+    market_returns = _daily_returns(market_points)
+    n = min(len(asset_returns), len(market_returns))
+    if n < 2:
+        return None
+    asset_slice = asset_returns[-n:]
+    market_slice = market_returns[-n:]
+    mean_asset = sum(asset_slice) / n
+    mean_market = sum(market_slice) / n
+    covariance = sum((a - mean_asset) * (m - mean_market) for a, m in zip(asset_slice, market_slice))
+    covariance /= n - 1
+    variance = sum((m - mean_market) ** 2 for m in market_slice) / (n - 1)
+    if variance == 0:
+        return None
+    return covariance / variance
+
+
+def _max_drawdown(points: Sequence[PricePoint]) -> Optional[float]:
+    if not points:
+        return None
+    peak = points[0].close
+    max_drawdown = 0.0
+    for point in points:
+        if point.close > peak:
+            peak = point.close
+        if peak == 0:
+            continue
+        drawdown = (point.close - peak) / peak
+        if drawdown < max_drawdown:
+            max_drawdown = drawdown
+    return max_drawdown
+
+
+def _drawdown_from_200dma(points: Sequence[PricePoint]) -> Optional[float]:
+    distance, _ = _distance_from_moving_average(points, 200)
+    return distance
+
+
+def _rsi_signal_stats(
+    points: Sequence[PricePoint], period: int = 14, forward: int = 30
+) -> Tuple[Optional[float], Optional[float]]:
+    if len(points) <= period + 1:
+        return None, None
+    closes = [point.close for point in points]
+    rsi_values: List[Tuple[int, float]] = []
+    for idx in range(period, len(closes)):
+        window = closes[idx - period : idx + 1]
+        rsi = _compute_rsi_from_window(window)
+        if rsi is None:
+            continue
+        rsi_values.append((idx, rsi))
+    if not rsi_values:
+        return None, None
+    signals = [item for item in rsi_values if item[1] < 30]
+    frequency = len(signals) / len(rsi_values) if rsi_values else None
+    forward_returns: List[float] = []
+    for idx, _ in signals:
+        start = closes[idx]
+        target_idx = min(idx + forward, len(closes) - 1)
+        end = closes[target_idx]
+        if start > 0:
+            forward_returns.append((end - start) / start)
+    median_forward = statistics.median(forward_returns) if forward_returns else None
+    return frequency, median_forward
+
+
+@dataclass
+class ProviderConfig:
+    base_url: str
+    api_key: str | None
+    max_retries: int
+    backoff_seconds: int
+    cache_ttl_seconds: int
+
+
+class MarketDataProvider:
+    """Facade that chooses between live and sample backends."""
+
+    def __init__(self, config: ProviderConfig, use_sample: bool | None = None) -> None:
+        self.logger = setup_logger(__name__)
+        if use_sample is None:
+            use_sample = not bool(config.api_key)
+        self.use_sample = use_sample
+        if use_sample:
+            self.backend: BaseBackend = SampleBackend()
+            self.logger.warning(
+                "Using sample data backend. Provide a DATA_API_KEY to enable live data."
+            )
+        else:
+            self.backend = PolygonBackend(config)
+
+    def load_candidates(self, run_date: date, expanded: bool = False) -> List[CandidateMetrics]:
+        """Return potential candidates."""
+        return self.backend.load_candidates(run_date, expanded)
+
+
+class BaseBackend:
+    """Base backend interface."""
+
+    def load_candidates(self, run_date: date, expanded: bool = False) -> List[CandidateMetrics]:
+        raise NotImplementedError
+
+
+class PolygonBackend(BaseBackend):
+    """Polygon.io backed data provider."""
+
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+        self.logger = setup_logger(__name__)
+        if not config.api_key:
+            raise ValueError("PolygonBackend requires an API key")
+        try:
+            import requests  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError("requests is required for Polygon backend") from exc
+        self._requests = requests
+        self.session = requests.Session()
+        self.session.headers.update({"Authorization": f"Bearer {config.api_key}"})
+        self._news_keywords = [
+            "guidance",
+            "restatement",
+            "sec",
+            "delisting",
+            "fraud",
+            "fda",
+            "trial",
+            "crl",
+            "pdufa",
+            "going concern",
+        ]
+        self._market_proxy = "SPY"
+        self._max_trigger_universe = 250
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None, allow_404: bool = False) -> Dict[str, Any]:
+        url = f"{self.config.base_url}{path}"
+        delay = max(self.config.backoff_seconds, 1)
+        for attempt in range(self.config.max_retries + 1):
+            response = self.session.get(url, params=params, timeout=30)
+            status = response.status_code
+            if status == 404 and allow_404:
+                return {}
+            if status in {429, 500, 502, 503, 504}:
+                sleep_for = delay * (2**attempt)
+                time.sleep(sleep_for + random.uniform(0, 0.5))
+                continue
+            if status >= 400:
+                self.logger.error("Polygon API error %s: %s", status, response.text)
+                response.raise_for_status()
+            try:
+                return response.json()
+            except ValueError as exc:  # pragma: no cover - invalid response
+                raise RuntimeError("Failed to decode Polygon response") from exc
+        raise RuntimeError("Polygon API request failed after retries")
+
+    def load_candidates(self, run_date: date, expanded: bool = False) -> List[CandidateMetrics]:  # type: ignore[override]
+        self.logger.info("Fetching Polygon data for %s (expanded=%s)", run_date, expanded)
+        todays_data = self._grouped_agg(run_date)
+        if not todays_data:
+            self.logger.warning("No grouped aggregates returned for %s", run_date)
+            return []
+        prev_day = self._previous_trading_day(run_date)
+        if prev_day is None:
+            self.logger.warning("Unable to determine previous trading day for %s", run_date)
+            return []
+        prev_data = self._grouped_agg(prev_day)
+        triggered = self._screen_for_triggers(todays_data, prev_data, run_date, expanded)
+        candidates: List[CandidateMetrics] = []
+        market_history = self._get_price_history(self._market_proxy, run_date - timedelta(days=365 * 5), run_date)
+        for ticker, bar, trigger, reasons in triggered:
+            try:
+                metrics = self._build_candidate_metrics(
+                    ticker,
+                    bar,
+                    prev_data.get(ticker),
+                    run_date,
+                    trigger,
+                    reasons,
+                    market_history,
+                )
+            except Exception as exc:  # pragma: no cover - defensive guard
+                self.logger.warning("Skipping %s due to data error: %s", ticker, exc)
+                continue
+            candidates.append(metrics)
+        return candidates
+
+    @in_memory_cache()
+    def _grouped_agg(self, target_date: date) -> Dict[str, Dict[str, Any]]:
+        path = f"/v2/aggs/grouped/locale/us/market/stocks/{target_date.isoformat()}"
+        payload = self._get(path, params={"adjusted": "true"}, allow_404=True)
+        results = {}
+        for item in payload.get("results", []):
+            ticker = item.get("T")
+            if not ticker:
+                continue
+            results[ticker] = item
+        return results
+
+    def _previous_trading_day(self, run_date: date) -> Optional[date]:
+        for offset in range(1, 7):
+            candidate = run_date - timedelta(days=offset)
+            if self._grouped_agg(candidate):
+                return candidate
+        return None
+
+    def _screen_for_triggers(
+        self,
+        todays: Dict[str, Dict[str, Any]],
+        previous: Dict[str, Dict[str, Any]],
+        run_date: date,
+        expanded: bool,
+    ) -> List[Tuple[str, Dict[str, Any], str, List[str]]]:
+        entries: List[Tuple[str, Dict[str, Any], float]] = []
+        for ticker, bar in todays.items():
+            prev = previous.get(ticker)
+            prev_close = prev.get("c") if prev else None
+            close = bar.get("c")
+            if not prev_close or not close or prev_close <= 0:
+                continue
+            change = (close - prev_close) / prev_close
+            entries.append((ticker, bar, change))
+        entries.sort(key=lambda item: item[2])
+        # Limit the universe we examine deeply for performance reasons.
+        entries = entries[: self._max_trigger_universe]
+        triggered: List[Tuple[str, Dict[str, Any], str, List[str]]] = []
+        for ticker, bar, change in entries:
+            trigger_name: Optional[str] = None
+            reasons: List[str] = []
+            if change <= -0.40:
+                trigger_name = "1-day −40%"
+                reasons.append(f"1d move {change:.2%}")
+            distance: Optional[float] = None
+            if trigger_name is None:
+                threshold = -0.04 if expanded else -0.08
+                if change <= threshold:
+                    history_1y = self._get_price_history(
+                        ticker, run_date - timedelta(days=370), run_date
+                    )
+                    distance = _distance_from_high(history_1y, 252) or 0.0
+                    if distance <= -0.40:
+                        trigger_name = "52w −40% + down day"
+                        reasons.append(
+                            f"52w drawdown {distance:.2%}, 1d {change:.2%}"
+                        )
+            if trigger_name is None:
+                continue
+            bar_copy = dict(bar)
+            bar_copy["change"] = change
+            if distance is not None:
+                bar_copy["distance_52w"] = distance
+            triggered.append((ticker, bar_copy, trigger_name, reasons))
+        return triggered
+
+    def _build_candidate_metrics(
+        self,
+        ticker: str,
+        bar: Dict[str, Any],
+        prev_bar: Optional[Dict[str, Any]],
+        run_date: date,
+        trigger: str,
+        reasons: List[str],
+        market_history: Sequence[PricePoint],
+    ) -> CandidateMetrics:
+        details = self._get_ticker_details(ticker)
+        profile = self._get_company_profile(ticker)
+        company_name = details.get("name") or profile.get("name") or ticker
+        sector = profile.get("sector") or profile.get("sic_description") or "Unknown"
+        industry = profile.get("industry") or profile.get("sic_description") or sector
+        market_cap = details.get("market_cap")
+        share_count = details.get("share_class_shares_outstanding")
+        price = bar.get("c", 0.0)
+        if market_cap is None and share_count:
+            market_cap = price * share_count
+        market_cap = market_cap or 0.0
+
+        history_5y = self._get_price_history(ticker, run_date - timedelta(days=365 * 5 + 30), run_date)
+        if not history_5y:
+            raise RuntimeError(f"No price history for {ticker}")
+        history_sorted = sorted(history_5y, key=lambda point: point.date)
+        change_1d = bar.get("change")
+        if change_1d is None and prev_bar and prev_bar.get("c"):
+            prev_close = prev_bar.get("c")
+            if prev_close:
+                change_1d = (price - prev_close) / prev_close
+        change_5d = _percent_change(history_sorted, 5)
+        change_1m = _percent_change(history_sorted, 21)
+        change_6m = _percent_change(history_sorted, 126)
+        change_1y = _percent_change(history_sorted, 252)
+        change_5y = _percent_change(history_sorted, 252 * 5)
+        distance_52w = bar.get("distance_52w")
+        if distance_52w is None:
+            distance_52w = _distance_from_high(history_sorted, 252)
+        distance_200, percent_to_200 = _distance_from_moving_average(history_sorted, 200)
+        rsi_14 = _calculate_rsi(history_sorted)
+        realized_vol = _calculate_realized_vol(history_sorted)
+        avg_dollar_volume = _calculate_avg_dollar_volume(history_sorted)
+        beta = _calculate_beta(history_sorted, market_history)
+
+        financials_q = self._get_financials(ticker, timeframe="quarterly", limit=16)
+        financials_a = self._get_financials(ticker, timeframe="annual", limit=6)
+        fundamentals = self._compute_fundamentals(
+            financials_q,
+            financials_a,
+            market_cap,
+            price,
+        )
+        short_interest = self._get_short_interest(ticker)
+        insider_buy = self._get_insider_activity(ticker)
+        earnings_date, last_earnings = self._get_earnings_window(ticker, run_date)
+        headline_flags, sec_delinquent, going_concern = self._collect_headline_flags(ticker, run_date)
+
+        five_year_stats = self._build_five_year_stats(
+            history_sorted,
+            financials_a,
+        )
+
+        metrics = CandidateMetrics(
+            ticker=ticker,
+            company_name=company_name,
+            sector=sector,
+            industry=industry,
+            market_cap=market_cap,
+            price=price,
+            open_price=bar.get("o", 0.0),
+            high_price=bar.get("h", 0.0),
+            low_price=bar.get("l", 0.0),
+            change_1d=change_1d or 0.0,
+            change_5d=change_5d or 0.0,
+            change_1m=change_1m or 0.0,
+            change_6m=change_6m or 0.0,
+            change_1y=change_1y or 0.0,
+            change_5y=change_5y,
+            distance_from_52w_high=distance_52w or 0.0,
+            distance_from_200dma=distance_200,
+            percent_to_200dma=percent_to_200,
+            rsi_14=rsi_14,
+            beta=beta,
+            realized_vol_30d=realized_vol,
+            short_interest_percent=short_interest,
+            avg_dollar_volume=avg_dollar_volume or 0.0,
+            shares_outstanding_trend=fundamentals.get("shares_trend"),
+            free_cash_flow_yield=fundamentals.get("fcf_yield"),
+            ev_to_ebitda=fundamentals.get("ev_to_ebitda"),
+            pe_ratio=fundamentals.get("pe"),
+            pb_ratio=fundamentals.get("pb"),
+            ps_ratio=fundamentals.get("ps"),
+            gross_margin=fundamentals.get("gross_margin"),
+            gross_margin_stability=fundamentals.get("gross_margin_stability"),
+            operating_margin=fundamentals.get("operating_margin"),
+            revenue_cagr_3y=fundamentals.get("revenue_cagr"),
+            roic=fundamentals.get("roic"),
+            net_debt_to_ebitda=fundamentals.get("net_debt_to_ebitda"),
+            interest_coverage=fundamentals.get("interest_coverage"),
+            operating_cash_flow_positive=fundamentals.get("operating_cash_flow_positive", False),
+            insider_net_buy_percent=insider_buy,
+            earnings_date=earnings_date,
+            last_earnings_date=last_earnings,
+            headline_flags=headline_flags,
+            sec_delinquent=sec_delinquent,
+            going_concern=going_concern,
+            trading_halted=False,
+            price_history_5y=history_sorted,
+            five_year_stats=five_year_stats,
+        )
+        metrics.trigger = trigger
+        metrics.triggered_conditions = reasons
+        return metrics
+
+    @in_memory_cache()
+    def _get_ticker_details(self, ticker: str) -> Dict[str, Any]:
+        payload = self._get(f"/v3/reference/tickers/{ticker}")
+        return payload.get("results", {}) if payload else {}
+
+    @in_memory_cache()
+    def _get_company_profile(self, ticker: str) -> Dict[str, Any]:
+        payload = self._get(f"/v1/meta/symbols/{ticker}/company", allow_404=True)
+        return payload or {}
+
+    @in_memory_cache()
+    def _get_financials(
+        self, ticker: str, timeframe: str, limit: int
+    ) -> List[Dict[str, Any]]:
+        params = {"ticker": ticker, "timeframe": timeframe, "limit": limit, "order": "desc"}
+        payload = self._get("/v3/reference/financials", params=params, allow_404=True)
+        results = payload.get("results", []) if payload else []
+        return sorted(
+            results,
+            key=lambda item: item.get("calendar_date") or item.get("start_date") or "",
+            reverse=True,
+        )
+
+    @in_memory_cache()
+    def _get_price_history(
+        self, ticker: str, start: date, end: date
+    ) -> List[PricePoint]:
+        params = {
+            "adjusted": "true",
+            "sort": "asc",
+            "limit": 5000,
+        }
+        path = f"/v2/aggs/ticker/{ticker}/range/1/day/{start.isoformat()}/{end.isoformat()}"
+        payload = self._get(path, params=params, allow_404=True)
+        points: List[PricePoint] = []
+        for item in payload.get("results", []) if payload else []:
+            timestamp = item.get("t")
+            close = item.get("c")
+            volume = item.get("v")
+            if timestamp is None or close is None:
+                continue
+            bar_date = datetime.utcfromtimestamp(timestamp / 1000).date()
+            points.append(PricePoint(date=bar_date, close=float(close), volume=float(volume) if volume else None))
+        return points
+
+    @in_memory_cache()
+    def _get_short_interest(self, ticker: str) -> Optional[float]:
+        payload = self._get(
+            "/v3/reference/short_interest",
+            params={"ticker": ticker, "limit": 1, "order": "desc"},
+            allow_404=True,
+        )
+        results = payload.get("results") if payload else None
+        if not results:
+            return None
+        latest = results[0]
+        float_shares = latest.get("float_shares") or latest.get("free_float")
+        short_interest = latest.get("short_interest") or latest.get("short_position")
+        if not float_shares or not short_interest:
+            return None
+        if float_shares == 0:
+            return None
+        return float(short_interest) / float(float_shares)
+
+    @in_memory_cache()
+    def _get_insider_activity(self, ticker: str) -> Optional[float]:
+        payload = self._get(
+            "/v3/reference/insiders",
+            params={"ticker": ticker, "limit": 20, "order": "desc"},
+            allow_404=True,
+        )
+        results = payload.get("results") if payload else None
+        if not results:
+            return None
+        net_shares = 0.0
+        total_shares = 0.0
+        for item in results:
+            shares = item.get("shares_transacted") or 0.0
+            if not shares:
+                continue
+            total_shares += abs(shares)
+            direction = item.get("transaction_type", "").lower()
+            if "buy" in direction:
+                net_shares += shares
+            elif "sell" in direction:
+                net_shares -= abs(shares)
+        if total_shares == 0:
+            return None
+        return net_shares / total_shares
+
+    def _get_earnings_window(
+        self, ticker: str, run_date: date
+    ) -> Tuple[Optional[date], Optional[date]]:
+        payload = self._get(
+            "/v3/reference/earnings",
+            params={"ticker": ticker, "limit": 10, "order": "desc"},
+            allow_404=True,
+        )
+        results = payload.get("results") if payload else []
+        upcoming: Optional[date] = None
+        last: Optional[date] = None
+        for item in results:
+            report_date_str = item.get("report_date") or item.get("fiscal_period_end")
+            if not report_date_str:
+                continue
+            report_date = datetime.fromisoformat(report_date_str).date()
+            if report_date >= run_date:
+                upcoming = report_date
+            elif last is None or report_date > last:
+                last = report_date
+        return upcoming, last
+
+    def _collect_headline_flags(
+        self, ticker: str, run_date: date
+    ) -> Tuple[List[str], bool, bool]:
+        since = (run_date - timedelta(days=5)).isoformat()
+        payload = self._get(
+            "/v2/reference/news",
+            params={"ticker": ticker, "published_utc.gte": since, "limit": 50},
+            allow_404=True,
+        )
+        results = payload.get("results") if payload else []
+        flags: List[str] = []
+        sec_delinquent = False
+        going_concern = False
+        for item in results:
+            headline = (item.get("title") or "").lower()
+            for keyword in self._news_keywords:
+                if keyword in headline:
+                    flags.append(item.get("title", ""))
+                    if "going concern" in headline:
+                        going_concern = True
+                    if "sec" in headline and "delin" in headline:
+                        sec_delinquent = True
+                    break
+        unique_flags = list(dict.fromkeys(flags))
+        return unique_flags, sec_delinquent, going_concern
+
+    def _compute_fundamentals(
+        self,
+        financials_q: Sequence[Dict[str, Any]],
+        financials_a: Sequence[Dict[str, Any]],
+        market_cap: float,
+        price: float,
+    ) -> Dict[str, Any]:
+        def extract(entry: Dict[str, Any], section: str, *candidates: str) -> Optional[float]:
+            financials = entry.get("financials", {}) if entry else {}
+            data = financials.get(section, {}) if isinstance(financials, dict) else {}
+            for key in candidates:
+                value = data.get(key)
+                if value is None:
+                    continue
+                if isinstance(value, dict):
+                    raw = value.get("value")
+                    if raw is not None:
+                        return float(raw)
+                elif isinstance(value, (int, float)):
+                    return float(value)
+            return None
+
+        def ttm_sum(section: str, *fields: str) -> Optional[float]:
+            selected = financials_q[:4]
+            if len(selected) < 4:
+                return None
+            totals: List[float] = []
+            for entry in selected:
+                value = extract(entry, section, *fields)
+                if value is None:
+                    return None
+                totals.append(value)
+            return sum(totals)
+
+        revenue_ttm = ttm_sum("income_statement", "revenues", "revenue", "sales")
+        gross_profit_ttm = ttm_sum("income_statement", "gross_profit")
+        operating_income_ttm = ttm_sum("income_statement", "operating_income", "income_from_operations")
+        ebitda_ttm = ttm_sum("income_statement", "ebitda")
+        net_income_ttm = ttm_sum("income_statement", "net_income")
+        interest_expense_ttm = ttm_sum("income_statement", "interest_expense")
+        operating_cash_flow_ttm = ttm_sum(
+            "cash_flow_statement", "net_cash_flow_from_operating_activities", "operating_cash_flow"
+        )
+        capex_ttm = ttm_sum("cash_flow_statement", "capital_expenditure", "capital_expenditures")
+        cash_latest = extract(financials_q[0], "balance_sheet", "cash_and_cash_equivalents", "cash") if financials_q else None
+        total_debt_latest = extract(
+            financials_q[0],
+            "balance_sheet",
+            "total_debt",
+            "long_term_debt",
+            "short_term_debt",
+        ) if financials_q else None
+        shareholders_equity_latest = extract(
+            financials_q[0],
+            "balance_sheet",
+            "shareholders_equity",
+            "total_shareholder_equity",
+        ) if financials_q else None
+        total_assets_latest = extract(
+            financials_q[0],
+            "balance_sheet",
+            "total_assets",
+            "assets",
+        ) if financials_q else None
+        current_liabilities_latest = extract(
+            financials_q[0],
+            "balance_sheet",
+            "current_liabilities",
+        ) if financials_q else None
+        shares_outstanding_latest = extract(
+            financials_q[0],
+            "income_statement",
+            "weighted_average_shares_outstanding_basic",
+            "weighted_average_shares_outstanding_diluted",
+        ) if financials_q else None
+
+        free_cash_flow_ttm = None
+        if operating_cash_flow_ttm is not None and capex_ttm is not None:
+            free_cash_flow_ttm = operating_cash_flow_ttm - capex_ttm
+        fcf_yield = None
+        if free_cash_flow_ttm is not None and market_cap > 0:
+            fcf_yield = free_cash_flow_ttm / market_cap
+
+        ev = None
+        if market_cap and total_debt_latest is not None:
+            cash_value = cash_latest or 0.0
+            ev = market_cap + total_debt_latest - cash_value
+        ev_to_ebitda = None
+        if ev is not None and ebitda_ttm and ebitda_ttm != 0:
+            ev_to_ebitda = ev / ebitda_ttm
+
+        pe = None
+        if net_income_ttm and net_income_ttm != 0 and shares_outstanding_latest:
+            eps = net_income_ttm / shares_outstanding_latest
+            if eps != 0:
+                pe = price / eps
+
+        pb = None
+        if shareholders_equity_latest and shareholders_equity_latest != 0 and shares_outstanding_latest:
+            book_value_per_share = shareholders_equity_latest / shares_outstanding_latest
+            if book_value_per_share != 0:
+                pb = price / book_value_per_share
+
+        ps = None
+        if revenue_ttm and revenue_ttm != 0:
+            ps = market_cap / revenue_ttm
+
+        gross_margin = None
+        if gross_profit_ttm is not None and revenue_ttm:
+            if revenue_ttm != 0:
+                gross_margin = gross_profit_ttm / revenue_ttm
+
+        operating_margin = None
+        if operating_income_ttm is not None and revenue_ttm:
+            if revenue_ttm != 0:
+                operating_margin = operating_income_ttm / revenue_ttm
+
+        interest_coverage = None
+        if operating_income_ttm is not None and interest_expense_ttm:
+            if interest_expense_ttm != 0:
+                interest_coverage = operating_income_ttm / interest_expense_ttm
+
+        net_debt_to_ebitda = None
+        if total_debt_latest is not None and cash_latest is not None and ebitda_ttm and ebitda_ttm != 0:
+            net_debt_to_ebitda = (total_debt_latest - cash_latest) / ebitda_ttm
+
+        operating_cash_flow_positive = bool(operating_cash_flow_ttm and operating_cash_flow_ttm > 0)
+
+        revenue_cagr = None
+        if len(financials_a) >= 4:
+            recent_revenue = extract(
+                financials_a[0], "income_statement", "revenues", "revenue", "sales"
+            )
+            old_revenue = extract(
+                financials_a[3], "income_statement", "revenues", "revenue", "sales"
+            )
+            if recent_revenue and old_revenue and old_revenue > 0:
+                years = 3
+                revenue_cagr = (recent_revenue / old_revenue) ** (1 / years) - 1
+
+        gross_margin_values: List[float] = []
+        for entry in financials_q[:12]:
+            revenue = extract(entry, "income_statement", "revenues", "revenue", "sales")
+            gross_profit = extract(entry, "income_statement", "gross_profit")
+            if revenue and revenue != 0 and gross_profit is not None:
+                gross_margin_values.append(gross_profit / revenue)
+        gross_margin_stability = (
+            statistics.stdev(gross_margin_values) if len(gross_margin_values) >= 2 else None
+        )
+
+        roic = None
+        invested_capital = None
+        if total_assets_latest is not None and current_liabilities_latest is not None:
+            invested_capital = total_assets_latest - current_liabilities_latest
+            if cash_latest is not None:
+                invested_capital -= cash_latest
+        if invested_capital and invested_capital != 0 and operating_income_ttm is not None:
+            roic = operating_income_ttm / invested_capital
+
+        shares_trend = None
+        share_values: List[float] = []
+        for entry in financials_q[:12]:
+            value = extract(
+                entry,
+                "income_statement",
+                "weighted_average_shares_outstanding_basic",
+                "weighted_average_shares_outstanding_diluted",
+            )
+            if value is not None:
+                share_values.append(value)
+        if len(share_values) >= 2:
+            shares_trend = (share_values[0] - share_values[-1]) / share_values[-1] if share_values[-1] else None
+
+        return {
+            "fcf_yield": fcf_yield,
+            "ev_to_ebitda": ev_to_ebitda,
+            "pe": pe,
+            "pb": pb,
+            "ps": ps,
+            "gross_margin": gross_margin,
+            "gross_margin_stability": gross_margin_stability,
+            "operating_margin": operating_margin,
+            "revenue_cagr": revenue_cagr,
+            "roic": roic,
+            "net_debt_to_ebitda": net_debt_to_ebitda,
+            "interest_coverage": interest_coverage,
+            "operating_cash_flow_positive": operating_cash_flow_positive,
+            "shares_trend": shares_trend,
+        }
+
+    def _build_five_year_stats(
+        self,
+        history: Sequence[PricePoint],
+        financials_a: Sequence[Dict[str, Any]],
+    ) -> FiveYearStats:
+        closes = sorted(history, key=lambda point: point.date)
+        max_drawdown = _max_drawdown(closes)
+        drawdown_200dma = _drawdown_from_200dma(closes)
+        rsi_freq, forward_return = _rsi_signal_stats(closes)
+        medians = self._historical_medians(closes, financials_a)
+        return FiveYearStats(
+            median_pe=medians.get("pe"),
+            median_ev_to_ebitda=medians.get("ev_to_ebitda"),
+            median_gross_margin=medians.get("gross_margin"),
+            median_roic=medians.get("roic"),
+            rsi_under_30_frequency=rsi_freq,
+            median_forward_return_after_rsi=forward_return,
+            max_drawdown_pct=max_drawdown,
+            drawdown_from_200dma_pct=drawdown_200dma,
+        )
+
+    def _historical_medians(
+        self,
+        history: Sequence[PricePoint],
+        financials_a: Sequence[Dict[str, Any]],
+    ) -> Dict[str, Optional[float]]:
+        closes_map = {point.date: point.close for point in history}
+
+        def extract(entry: Dict[str, Any], section: str, *candidates: str) -> Optional[float]:
+            financials = entry.get("financials", {}) if entry else {}
+            data = financials.get(section, {}) if isinstance(financials, dict) else {}
+            for key in candidates:
+                value = data.get(key)
+                if value is None:
+                    continue
+                if isinstance(value, dict):
+                    raw = value.get("value")
+                    if raw is not None:
+                        return float(raw)
+                elif isinstance(value, (int, float)):
+                    return float(value)
+            return None
+
+        pe_values: List[float] = []
+        ev_ebitda_values: List[float] = []
+        gross_margin_values: List[float] = []
+        roic_values: List[float] = []
+
+        for entry in financials_a:
+            end_date_str = entry.get("calendar_date") or entry.get("start_date")
+            if not end_date_str:
+                continue
+            end_date = datetime.fromisoformat(end_date_str).date()
+            close = closes_map.get(end_date)
+            if close is None and history:
+                closest = min(history, key=lambda point: abs((point.date - end_date).days))
+                close = closest.close
+            if close is None:
+                continue
+
+            revenue = extract(entry, "income_statement", "revenues", "revenue", "sales")
+            gross_profit = extract(entry, "income_statement", "gross_profit")
+            operating_income = extract(entry, "income_statement", "operating_income", "income_from_operations")
+            ebitda = extract(entry, "income_statement", "ebitda")
+            net_income = extract(entry, "income_statement", "net_income")
+            shares = extract(
+                entry,
+                "income_statement",
+                "weighted_average_shares_outstanding_basic",
+                "weighted_average_shares_outstanding_diluted",
+            )
+            cash = extract(entry, "balance_sheet", "cash_and_cash_equivalents", "cash")
+            total_debt = extract(entry, "balance_sheet", "total_debt", "long_term_debt", "short_term_debt")
+            assets = extract(entry, "balance_sheet", "total_assets", "assets")
+            current_liabilities = extract(entry, "balance_sheet", "current_liabilities")
+
+            if shares and net_income:
+                eps = net_income / shares if shares else None
+                if eps and eps != 0:
+                    pe_values.append(close / eps)
+            if shares and total_debt is not None and ebitda and ebitda != 0:
+                market_cap = close * shares
+                ev = market_cap + total_debt - (cash or 0.0)
+                ev_ebitda_values.append(ev / ebitda)
+            if revenue and revenue != 0 and gross_profit is not None:
+                gross_margin_values.append(gross_profit / revenue)
+            if (
+                operating_income is not None
+                and assets is not None
+                and current_liabilities is not None
+            ):
+                invested_capital = assets - current_liabilities - (cash or 0.0)
+                if invested_capital:
+                    roic_values.append(operating_income / invested_capital)
+
+        medians: Dict[str, Optional[float]] = {
+            "pe": statistics.median(pe_values) if pe_values else None,
+            "ev_to_ebitda": statistics.median(ev_ebitda_values) if ev_ebitda_values else None,
+            "gross_margin": statistics.median(gross_margin_values) if gross_margin_values else None,
+            "roic": statistics.median(roic_values) if roic_values else None,
+        }
+        return medians
+
+
+class SampleBackend(BaseBackend):
+    """Generate deterministic sample data suitable for tests and dry runs."""
+
+    def __init__(self) -> None:
+        self.logger = setup_logger(__name__)
+        self._seed = 42
+
+    def load_candidates(self, run_date: date, expanded: bool = False) -> List[CandidateMetrics]:  # type: ignore[override]
+        rng = random.Random(self._seed)
+        tickers = [
+            ("ACME", "Acme Industrial", "Industrials"),
+            ("BIOX", "Biovex Labs", "Health Care"),
+            ("CTEC", "CyberTech Corp", "Information Technology"),
+            ("DRIL", "Drillers United", "Energy"),
+            ("EVGO", "Evergreen Goods", "Consumer Staples"),
+            ("FINS", "FinServe Group", "Financials"),
+            ("GLXY", "Galaxy Retail", "Consumer Discretionary"),
+            ("HOMR", "Home Repair Co", "Industrials"),
+            ("ICRX", "InnovaCare Rx", "Health Care"),
+            ("JETT", "Jetsetter Airlines", "Industrials"),
+            ("KART", "Kart Logistics", "Industrials"),
+            ("LUMN", "Lumina Media", "Communication Services"),
+        ]
+        results: List[CandidateMetrics] = []
+        base_price = 40.0
+        for idx, (ticker, name, sector) in enumerate(tickers):
+            price = base_price * (1 - 0.03 * idx)
+            change_1d = -0.41 + 0.01 * (idx % 3)
+            distance_52w = -0.42 - 0.02 * (idx % 4)
+            if idx % 4 == 0:
+                change_1d = -0.45
+            elif idx % 4 == 1:
+                change_1d = -0.12
+            elif idx % 4 == 2:
+                change_1d = -0.09
+            else:
+                change_1d = -0.5
+            revenue_cagr = 0.1 + 0.01 * (idx % 5)
+            rsi = 22 + (idx % 6)
+            distance_200dma = -0.25 - 0.01 * (idx % 7)
+            change_1m = -0.2 + 0.02 * (idx % 4)
+            change_6m = -0.35 + 0.015 * (idx % 5)
+            change_1y = -0.5 + 0.02 * (idx % 6)
+            change_5d = -0.12 + 0.01 * (idx % 5)
+            change_5y = 0.2 - 0.05 * (idx % 3)
+            pe = 8 + idx * 0.5
+            pb = 0.9 + 0.05 * (idx % 5)
+            ev_ebitda = 5 + 0.4 * (idx % 6)
+            roic = 0.12 - 0.005 * (idx % 4)
+            gross_margin = 0.35 - 0.01 * (idx % 4)
+            gm_stability = 0.04 + 0.005 * (idx % 3)
+            net_debt = 1.5 + 0.2 * (idx % 5)
+            interest_cov = 5 + 0.5 * (idx % 4)
+            adv = 8_000_000 + 500_000 * (idx % 5)
+            fcf_yield = 0.12 + 0.01 * (idx % 4)
+            beta = 1.1 - 0.1 * (idx % 5)
+            vol_30d = 0.55 + 0.02 * (idx % 4)
+            short_interest = 0.05 + 0.005 * (idx % 5)
+            insider_buy = 0.01 * (idx % 3)
+            share_trend = -0.01 * (idx % 4)
+            history = self._generate_price_history(price, rng)
+            stats = FiveYearStats(
+                median_pe=15.0,
+                median_ev_to_ebitda=8.5,
+                median_gross_margin=0.4,
+                median_roic=0.13,
+                rsi_under_30_frequency=0.18,
+                median_forward_return_after_rsi=0.045,
+                max_drawdown_pct=-0.62,
+                drawdown_from_200dma_pct=-0.28,
+            )
+            earnings_date = run_date + timedelta(days=7 + idx)
+            metrics = CandidateMetrics(
+                ticker=ticker,
+                company_name=name,
+                sector=sector,
+                industry=f"Industry {idx % 6}",
+                market_cap=800_000_000 + 50_000_000 * idx,
+                price=price,
+                open_price=price * 1.05,
+                high_price=price * 1.08,
+                low_price=price * 0.92,
+                change_1d=change_1d,
+                change_5d=change_5d,
+                change_1m=change_1m,
+                change_6m=change_6m,
+                change_1y=change_1y,
+                change_5y=change_5y,
+                distance_from_52w_high=distance_52w,
+                distance_from_200dma=distance_200dma,
+                percent_to_200dma=abs(distance_200dma),
+                rsi_14=rsi,
+                beta=beta,
+                realized_vol_30d=vol_30d,
+                short_interest_percent=short_interest,
+                avg_dollar_volume=adv,
+                shares_outstanding_trend=share_trend,
+                free_cash_flow_yield=fcf_yield,
+                ev_to_ebitda=ev_ebitda,
+                pe_ratio=pe,
+                pb_ratio=pb,
+                ps_ratio=1.2 + 0.05 * (idx % 4),
+                gross_margin=gross_margin,
+                gross_margin_stability=gm_stability,
+                operating_margin=0.18 - 0.01 * (idx % 4),
+                revenue_cagr_3y=revenue_cagr,
+                roic=roic,
+                net_debt_to_ebitda=net_debt,
+                interest_coverage=interest_cov,
+                operating_cash_flow_positive=True,
+                insider_net_buy_percent=insider_buy,
+                earnings_date=earnings_date,
+                last_earnings_date=run_date - timedelta(days=50),
+                headline_flags=[] if idx % 5 else ["Guidance cut"],
+                sec_delinquent=False,
+                going_concern=False,
+                trading_halted=False,
+                price_history_5y=history,
+                five_year_stats=stats,
+            )
+            if idx % 5 == 0:
+                metrics.add_flag("Guidance")
+            results.append(metrics)
+        if not expanded:
+            return results
+        # When expanded criteria requested, adjust drawdown thresholds to include milder drops.
+        for metrics in results:
+            if metrics.change_1d > -0.04:
+                metrics.change_1d = -0.05
+            if metrics.distance_from_52w_high < -0.2:
+                continue
+            metrics.distance_from_52w_high -= 0.2
+        return results
+
+    def _generate_price_history(
+        self, last_price: float, rng: random.Random, days: int = 252 * 5
+    ) -> Sequence[PricePoint]:
+        prices: List[PricePoint] = []
+        current_price = last_price
+        start_date = datetime.utcnow().date() - timedelta(days=days)
+        for offset in range(days):
+            day = start_date + timedelta(days=offset)
+            if day.weekday() >= 5:
+                continue
+            drift = rng.gauss(-0.0002, 0.02)
+            current_price *= max(0.1, 1 + drift)
+            prices.append(PricePoint(date=day, close=round(current_price, 2)))
+        return prices[-750:]

--- a/value_stocks/filters.py
+++ b/value_stocks/filters.py
@@ -1,0 +1,109 @@
+"""Filter logic for candidate screening."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List, Tuple
+
+from .models import CandidateMetrics, FilterResult
+
+
+def determine_drop_trigger(
+    metrics: CandidateMetrics,
+    expanded: bool = False,
+) -> Tuple[bool, str | None, List[str]]:
+    """Determine if the stock satisfies the drop condition."""
+
+    triggered_reasons: List[str] = []
+    trigger_name: str | None = None
+    passed = False
+
+    if metrics.change_1d is not None and metrics.change_1d <= -0.40:
+        passed = True
+        trigger_name = "1-day −40%"
+        triggered_reasons.append(f"1d move {metrics.change_1d:.2%}")
+
+    drawdown_threshold = -0.40 if not expanded else -0.40
+    day_change_threshold = -0.08 if not expanded else -0.04
+
+    if (
+        metrics.distance_from_52w_high is not None
+        and metrics.distance_from_52w_high <= drawdown_threshold
+        and metrics.change_1d is not None
+        and metrics.change_1d <= day_change_threshold
+    ):
+        passed = True
+        if trigger_name is None:
+            trigger_name = "52w −40% + down day"
+        triggered_reasons.append(
+            f"52w drawdown {metrics.distance_from_52w_high:.2%}, 1d {metrics.change_1d:.2%}"
+        )
+
+    return passed, trigger_name, triggered_reasons
+
+
+def passes_value_filters(
+    metrics: CandidateMetrics,
+    config: Dict[str, float],
+    run_date: date,
+) -> FilterResult:
+    """Apply the hard survivability filters."""
+
+    reasons: List[str] = []
+
+    if metrics.trading_halted:
+        reasons.append("Trading halted today")
+
+    if not metrics.operating_cash_flow_positive:
+        reasons.append("Negative operating cash flow")
+
+    max_net_debt = config.get("max_net_debt_ebitda", 4)
+    if metrics.net_debt_to_ebitda is None:
+        reasons.append("Missing net debt/EBITDA")
+    elif metrics.net_debt_to_ebitda > max_net_debt and metrics.net_debt_to_ebitda > 0:
+        reasons.append("Net debt/EBITDA above limit")
+
+    min_interest = config.get("min_interest_coverage", 3)
+    if metrics.interest_coverage is None or metrics.interest_coverage < min_interest:
+        reasons.append("Interest coverage below threshold")
+
+    allowed_low_margin = set(config.get("allow_low_margin_sectors", []))
+    min_margin = config.get("min_gross_margin", 0.15)
+    if metrics.gross_margin is None:
+        reasons.append("Missing gross margin")
+    else:
+        if metrics.sector not in allowed_low_margin and metrics.gross_margin < min_margin:
+            reasons.append("Gross margin below threshold")
+
+    earnings_buffer = int(config.get("earnings_days_buffer", 2))
+    if metrics.earnings_date is not None:
+        delta_days = (metrics.earnings_date - run_date).days
+        if abs(delta_days) <= earnings_buffer:
+            reasons.append("Within earnings blackout window")
+
+    flagged_window_days = int(config.get("flagged_headline_window_days", 3))
+    if metrics.headline_flags and flagged_window_days >= 0:
+        reasons.append("Recent headline risk")
+
+    if metrics.sec_delinquent:
+        reasons.append("SEC delinquency flagged")
+
+    if metrics.going_concern:
+        reasons.append("Going concern risk")
+
+    passed = len(reasons) == 0
+    return FilterResult(passed=passed, reasons=reasons)
+
+
+def earnings_window_status(metrics: CandidateMetrics, config: Dict[str, float], run_date: date) -> str:
+    """Return the status for the earnings window select field."""
+
+    buffer_days = int(config.get("earnings_days_buffer", 2))
+    window_days = int(config.get("earnings_window_days", 10))
+    if metrics.earnings_date is None:
+        return "Safe"
+    delta_days = (metrics.earnings_date - run_date).days
+    if abs(delta_days) <= buffer_days:
+        return "Inside 2d"
+    if abs(delta_days) <= window_days:
+        return "Near"
+    return "Safe"

--- a/value_stocks/models.py
+++ b/value_stocks/models.py
@@ -1,0 +1,143 @@
+"""Dataclasses for the screening pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass
+class PricePoint:
+    """Simple price point used for charting."""
+
+    date: date
+    close: float
+    volume: float | None = None
+
+
+@dataclass
+class FiveYearStats:
+    """Contextual statistics for five year lookback."""
+
+    median_pe: Optional[float] = None
+    median_ev_to_ebitda: Optional[float] = None
+    median_gross_margin: Optional[float] = None
+    median_roic: Optional[float] = None
+    rsi_under_30_frequency: Optional[float] = None
+    median_forward_return_after_rsi: Optional[float] = None
+    max_drawdown_pct: Optional[float] = None
+    drawdown_from_200dma_pct: Optional[float] = None
+
+
+@dataclass
+class CandidateMetrics:
+    """Metrics used for scoring and filtering."""
+
+    ticker: str
+    company_name: str
+    sector: str
+    industry: str
+    market_cap: float
+    price: float
+    open_price: float
+    high_price: float
+    low_price: float
+    change_1d: float
+    change_5d: float
+    change_1m: float
+    change_6m: float
+    change_1y: float
+    change_5y: Optional[float]
+    distance_from_52w_high: float
+    distance_from_200dma: Optional[float]
+    percent_to_200dma: Optional[float]
+    rsi_14: Optional[float]
+    beta: Optional[float]
+    realized_vol_30d: Optional[float]
+    short_interest_percent: Optional[float]
+    avg_dollar_volume: float
+    shares_outstanding_trend: Optional[float]
+    free_cash_flow_yield: Optional[float]
+    ev_to_ebitda: Optional[float]
+    pe_ratio: Optional[float]
+    pb_ratio: Optional[float]
+    ps_ratio: Optional[float]
+    gross_margin: Optional[float]
+    gross_margin_stability: Optional[float]
+    operating_margin: Optional[float]
+    revenue_cagr_3y: Optional[float]
+    roic: Optional[float]
+    net_debt_to_ebitda: Optional[float]
+    interest_coverage: Optional[float]
+    operating_cash_flow_positive: bool
+    insider_net_buy_percent: Optional[float]
+    earnings_date: Optional[date]
+    last_earnings_date: Optional[date]
+    headline_flags: List[str] = field(default_factory=list)
+    sec_delinquent: bool = False
+    going_concern: bool = False
+    trading_halted: bool = False
+    price_history_5y: Sequence[PricePoint] = field(default_factory=list)
+    five_year_stats: FiveYearStats = field(default_factory=FiveYearStats)
+    trigger: Optional[str] = None
+    triggered_conditions: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    chart_path: Optional[str] = None
+
+    def add_flag(self, flag: str) -> None:
+        if flag not in self.headline_flags:
+            self.headline_flags.append(flag)
+
+
+@dataclass
+class FilterResult:
+    """Outcome of running the filter checks."""
+
+    passed: bool
+    reasons: List[str]
+
+
+@dataclass
+class ScoreBreakdown:
+    """Stores the component scores for a candidate."""
+
+    total: float
+    valuation: float
+    quality: float
+    momentum: float
+    risk: float
+    liquidity: float
+    penalties: float
+    normalized_inputs: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class CandidateResult:
+    """Final aggregated result for a candidate."""
+
+    metrics: CandidateMetrics
+    filter_result: FilterResult
+    score: ScoreBreakdown
+    rank: Optional[int] = None
+
+
+@dataclass
+class RunMetadata:
+    """Metadata about a pipeline execution."""
+
+    run_datetime: datetime
+    market_status: str
+    universe_size: int
+    considered: int
+    passed_filters: int
+    expanded_criteria_used: bool
+    data_source: str
+    api_warnings: List[str] = field(default_factory=list)
+    run_log_path: Optional[str] = None
+
+
+@dataclass
+class RulesBlock:
+    """Structured rules text for the report footer."""
+
+    bullets: List[str]

--- a/value_stocks/notion.py
+++ b/value_stocks/notion.py
@@ -1,0 +1,420 @@
+"""Minimal Notion integration layer."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import date
+from statistics import median
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import requests
+except ImportError:  # pragma: no cover - optional dependency
+    requests = None
+
+from .models import CandidateResult, RunMetadata
+from .utils import setup_logger
+
+
+class NotionService:
+    """Prepare and optionally send payloads to Notion."""
+
+    def __init__(self, token: Optional[str], database_id: Optional[str]) -> None:
+        self.logger = setup_logger(__name__)
+        self.token = token
+        self.database_id = database_id
+        self.enabled = bool(token and database_id)
+        self.session = requests.Session() if requests is not None else None
+        if self.enabled and self.session is not None:
+            self.session.headers.update(
+                {
+                    "Authorization": f"Bearer {token}",
+                    "Notion-Version": "2022-06-28",
+                    "Content-Type": "application/json",
+                }
+            )
+        else:
+            self.logger.warning("Notion credentials missing – falling back to console output")
+            if self.enabled and self.session is None:
+                self.logger.warning("requests not available; Notion push disabled")
+                self.enabled = False
+
+    def build_placeholder_page(self, run_date: date, metadata: RunMetadata) -> Dict[str, Any]:
+        title = f"Daily −40% Drop Value Screen – {run_date.isoformat()}"
+        return {
+            "title": title,
+            "metadata": asdict(metadata),
+            "summary": {
+                "message": "Market closed – no screening performed.",
+                "expanded": False,
+                "median_score": 0,
+            },
+            "candidates": [],
+            "rules": [],
+            "analysis": [],
+            "closest": [],
+        }
+
+    def build_report_payload(
+        self,
+        run_date: date,
+        candidates: List[CandidateResult],
+        all_candidates: List[CandidateResult],
+        metadata: RunMetadata,
+        rules_block: Iterable[str],
+        expanded: bool,
+    ) -> Dict[str, Any]:
+        title = f"Daily −40% Drop Value Screen – {run_date.isoformat()}"
+        table_rows = [self._build_row(candidate, metadata, run_date) for candidate in candidates]
+        all_scores = [candidate.score.total for candidate in candidates if candidate.score]
+        median_score = median(all_scores) if all_scores else 0.0
+        analysis_blocks = [self._build_analysis(candidate) for candidate in candidates]
+        closest = []
+        if not candidates:
+            self.logger.info("No passing candidates; selecting closest by score")
+            ranked = sorted(all_candidates, key=lambda item: item.score.total, reverse=True)
+            closest = [self._build_row(item, metadata, run_date) for item in ranked[:5]]
+        payload = {
+            "title": title,
+            "metadata": asdict(metadata),
+            "summary": {
+                "message": f"{len(candidates)} candidates selected.",
+                "expanded": expanded,
+                "median_score": median_score,
+            },
+            "candidates": table_rows,
+            "rules": list(rules_block),
+            "analysis": analysis_blocks,
+            "closest": closest,
+            "notes": [note for candidate in candidates for note in candidate.metrics.notes],
+        }
+        if not candidates:
+            payload["summary"]["message"] = "No candidates met criteria"
+        if expanded:
+            payload.setdefault("warnings", []).append("Expanded criteria used")
+        if metadata.api_warnings:
+            payload.setdefault("warnings", []).extend(metadata.api_warnings)
+        return payload
+
+    def dispatch(self, payload: Dict[str, Any], dry_run: bool) -> None:
+        if dry_run or not self.enabled:
+            print(json.dumps(payload, indent=2, default=str))
+            return
+        try:
+            self._push_to_notion(payload)
+        except Exception as exc:  # pragma: no cover - integration error
+            self.logger.error("Failed to push to Notion: %s", exc)
+            print(json.dumps(payload, indent=2, default=str))
+
+    def _push_to_notion(self, payload: Dict[str, Any]) -> None:
+        if self.session is None:
+            raise RuntimeError("HTTP client unavailable")
+        page_id = self._find_existing_page(payload["title"])
+        if page_id:
+            self.logger.info("Updating existing Notion page %s", page_id)
+            self._clear_children(page_id)
+        else:
+            page_id = self._create_page(payload)
+        self._append_blocks(page_id, payload)
+
+    def _build_row(self, candidate: CandidateResult, metadata: RunMetadata, run_date: date) -> Dict[str, Any]:
+        metrics = candidate.metrics
+        return {
+            "rank": candidate.rank,
+            "ticker": metrics.ticker,
+            "company": metrics.company_name,
+            "score": candidate.score.total,
+            "trigger": metrics.trigger,
+            "change_today": metrics.change_1d,
+            "change_5d": metrics.change_5d,
+            "change_1m": metrics.change_1m,
+            "change_1y": metrics.change_1y,
+            "fcf_yield": metrics.free_cash_flow_yield,
+            "ev_ebitda": metrics.ev_to_ebitda,
+            "pe": metrics.pe_ratio,
+            "pb": metrics.pb_ratio,
+            "roic": metrics.roic,
+            "revenue_cagr": metrics.revenue_cagr_3y,
+            "net_debt_ebitda": metrics.net_debt_to_ebitda,
+            "interest_coverage": metrics.interest_coverage,
+            "beta": metrics.beta,
+            "vol_30d": metrics.realized_vol_30d,
+            "short_interest": metrics.short_interest_percent,
+            "dollar_volume": metrics.avg_dollar_volume,
+            "earnings_window": metrics.earnings_date.isoformat() if metrics.earnings_date else None,
+            "flags": metrics.headline_flags,
+            "chart_path": metrics.chart_path,
+            "background": metrics.notes[-1] if metrics.notes else None,
+        }
+
+    def _build_analysis(self, candidate: CandidateResult) -> Dict[str, Any]:
+        metrics = candidate.metrics
+        stats = metrics.five_year_stats
+        lines = [
+            f"P/E {self._format_number(metrics.pe_ratio)} vs 5y {self._format_number(stats.median_pe)}",
+            f"EV/EBITDA {self._format_number(metrics.ev_to_ebitda)} vs 5y {self._format_number(stats.median_ev_to_ebitda)}",
+            f"Gross margin {self._format_percent(metrics.gross_margin)} vs 5y {self._format_percent(stats.median_gross_margin)}",
+            f"ROIC {self._format_percent(metrics.roic)} vs 5y {self._format_percent(stats.median_roic)}",
+        ]
+        if stats.max_drawdown_pct is not None:
+            lines.append(f"Drawdown from ATH {self._format_percent(stats.max_drawdown_pct)}")
+        if stats.drawdown_from_200dma_pct is not None:
+            lines.append(f"vs 200DMA {self._format_percent(stats.drawdown_from_200dma_pct)}")
+        if stats.rsi_under_30_frequency is not None and stats.median_forward_return_after_rsi is not None:
+            lines.append(
+                f"RSI<30 on {self._format_percent(stats.rsi_under_30_frequency)} of days; median {self._format_percent(stats.median_forward_return_after_rsi)} 30d forward"
+            )
+        lines.append("Not financial advice.")
+        return {"ticker": metrics.ticker, "lines": lines}
+
+    def _create_page(self, payload: Dict[str, Any]) -> str:
+        properties = {
+            "Ticker": {"title": [{"text": {"content": payload["title"]}}]},
+        }
+        body = {
+            "parent": {"database_id": self.database_id},
+            "properties": properties,
+        }
+        if self.session is None:
+            raise RuntimeError("HTTP client unavailable")
+        response = self.session.post("https://api.notion.com/v1/pages", json=body, timeout=30)
+        response.raise_for_status()
+        page_id = response.json()["id"]
+        return page_id
+
+    def _find_existing_page(self, title: str) -> Optional[str]:
+        if not self.database_id:
+            return None
+        if self.session is None:
+            return None
+        body = {
+            "filter": {
+                "property": "Ticker",
+                "title": {"equals": title},
+            }
+        }
+        response = self.session.post(
+            f"https://api.notion.com/v1/databases/{self.database_id}/query",
+            json=body,
+            timeout=30,
+        )
+        response.raise_for_status()
+        results = response.json().get("results", [])
+        if not results:
+            return None
+        return results[0]["id"]
+
+    def _clear_children(self, page_id: str) -> None:
+        url = f"https://api.notion.com/v1/blocks/{page_id}/children"
+        if self.session is None:
+            return
+        response = self.session.get(url, timeout=30)
+        response.raise_for_status()
+        results = response.json().get("results", [])
+        for block in results:
+            block_id = block.get("id")
+            if not block_id:
+                continue
+            self.session.patch(
+                f"https://api.notion.com/v1/blocks/{block_id}",
+                json={"archived": True},
+                timeout=30,
+            )
+
+    def _append_blocks(self, page_id: str, payload: Dict[str, Any]) -> None:
+        blocks: List[Dict[str, Any]] = []
+        summary_text = payload["summary"]["message"]
+        callout = {
+            "object": "block",
+            "type": "callout",
+            "callout": {
+                "rich_text": [{"type": "text", "text": {"content": summary_text}}],
+                "icon": {"emoji": "📉"},
+            },
+        }
+        blocks.append(callout)
+        if payload.get("warnings"):
+            warning_text = " | ".join(payload["warnings"])
+            blocks.append(
+                {
+                    "object": "block",
+                    "type": "callout",
+                    "callout": {
+                        "rich_text": [{"type": "text", "text": {"content": warning_text}}],
+                        "icon": {"emoji": "⚠️"},
+                    },
+                }
+            )
+        if payload["candidates"]:
+            table_block = self._build_table_block(payload["candidates"])
+            blocks.append(table_block)
+        elif payload.get("closest"):
+            blocks.append(
+                {
+                    "object": "block",
+                    "type": "bulleted_list_item",
+                    "bulleted_list_item": {
+                        "rich_text": [
+                            {
+                                "type": "text",
+                                "text": {"content": "Top 5 by score despite failing filters:"},
+                            }
+                        ]
+                    },
+                }
+            )
+            for item in payload["closest"]:
+                text = f"{item['ticker']} – score {self._format_number(item['score'])}"
+                blocks.append(
+                    {
+                        "object": "block",
+                        "type": "bulleted_list_item",
+                        "bulleted_list_item": {
+                            "rich_text": [
+                                {"type": "text", "text": {"content": text}}
+                            ]
+                        },
+                    }
+                )
+        if payload.get("analysis"):
+            for item in payload["analysis"]:
+                toggle_block = {
+                    "object": "block",
+                    "type": "toggle",
+                    "toggle": {
+                        "rich_text": [
+                            {"type": "text", "text": {"content": f"{item['ticker']} five-year context"}}
+                        ],
+                        "children": [
+                            {
+                                "object": "block",
+                                "type": "bulleted_list_item",
+                                "bulleted_list_item": {
+                                    "rich_text": [
+                                        {"type": "text", "text": {"content": line}}
+                                    ]
+                                },
+                            }
+                            for line in item["lines"]
+                        ],
+                    },
+                }
+                blocks.append(toggle_block)
+        if payload.get("rules"):
+            rules_children = [
+                {
+                    "object": "block",
+                    "type": "bulleted_list_item",
+                    "bulleted_list_item": {
+                        "rich_text": [{"type": "text", "text": {"content": rule}}]
+                    },
+                }
+                for rule in payload["rules"]
+            ]
+            blocks.append(
+                {
+                    "object": "block",
+                    "type": "heading_2",
+                    "heading_2": {"rich_text": [{"type": "text", "text": {"content": "Rules"}}]},
+                }
+            )
+            blocks.extend(rules_children)
+        if self.session is None:
+            raise RuntimeError("HTTP client unavailable")
+        url = f"https://api.notion.com/v1/blocks/{page_id}/children"
+        for chunk_start in range(0, len(blocks), 50):
+            chunk = blocks[chunk_start : chunk_start + 50]
+            response = self.session.patch(url, json={"children": chunk}, timeout=30)
+            response.raise_for_status()
+
+    def _build_table_block(self, rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+        columns = [
+            "Rank",
+            "Ticker",
+            "Company",
+            "Score",
+            "% Today",
+            "% 5D",
+            "% 1M",
+            "% 1Y",
+            "FCF Yield",
+            "EV/EBITDA",
+            "P/E",
+            "P/B",
+            "ROIC",
+            "Rev CAGR",
+            "Net Debt/EBITDA",
+            "Interest Cov",
+            "Beta",
+            "30D Vol",
+            "Short Interest",
+            "ADV",
+        ]
+        header_row = {
+            "object": "block",
+            "type": "table_row",
+            "table_row": {
+                "cells": [[{"type": "text", "text": {"content": col}}] for col in columns]
+            },
+        }
+        body_rows = []
+        for row in rows:
+            cells = [
+                self._cell(row.get("rank")),
+                self._cell(row.get("ticker")),
+                self._cell(row.get("company")),
+                self._cell(self._format_number(row.get("score"))),
+                self._cell(self._format_percent(row.get("change_today"))),
+                self._cell(self._format_percent(row.get("change_5d"))),
+                self._cell(self._format_percent(row.get("change_1m"))),
+                self._cell(self._format_percent(row.get("change_1y"))),
+                self._cell(self._format_percent(row.get("fcf_yield"))),
+                self._cell(self._format_number(row.get("ev_ebitda"))),
+                self._cell(self._format_number(row.get("pe"))),
+                self._cell(self._format_number(row.get("pb"))),
+                self._cell(self._format_percent(row.get("roic"))),
+                self._cell(self._format_percent(row.get("revenue_cagr"))),
+                self._cell(self._format_number(row.get("net_debt_ebitda"))),
+                self._cell(self._format_number(row.get("interest_coverage"))),
+                self._cell(self._format_number(row.get("beta"))),
+                self._cell(self._format_percent(row.get("vol_30d"))),
+                self._cell(self._format_percent(row.get("short_interest"))),
+                self._cell(self._format_dollar(row.get("dollar_volume"))),
+            ]
+            body_rows.append({"object": "block", "type": "table_row", "table_row": {"cells": cells}})
+        return {
+            "object": "block",
+            "type": "table",
+            "table": {
+                "table_width": len(columns),
+                "has_column_header": True,
+                "has_row_header": False,
+            },
+            "children": [header_row] + body_rows,
+        }
+
+    def _cell(self, content: Any) -> List[Dict[str, Any]]:
+        if content is None:
+            content = "N/A"
+        else:
+            content = str(content)
+        return [{"type": "text", "text": {"content": content}}]
+
+    def _format_percent(self, value: Optional[float]) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value * 100:.1f}%"
+
+    def _format_number(self, value: Optional[float]) -> str:
+        if value is None:
+            return "N/A"
+        return f"{value:.2f}"
+
+    def _format_dollar(self, value: Optional[float]) -> str:
+        if value is None:
+            return "N/A"
+        if value >= 1_000_000:
+            return f"${value/1_000_000:.1f}M"
+        if value >= 1_000:
+            return f"${value/1_000:.1f}K"
+        return f"${value:.0f}"

--- a/value_stocks/report.py
+++ b/value_stocks/report.py
@@ -1,0 +1,294 @@
+"""Pipeline orchestration for the daily screen."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from .background import build_background_blurb
+from .charts import generate_price_chart
+from .config_loader import AppConfig
+from .data_provider import MarketDataProvider, ProviderConfig
+from .filters import determine_drop_trigger, passes_value_filters
+from .models import CandidateMetrics, CandidateResult, RunMetadata, ScoreBreakdown
+from .notion import NotionService
+from .scoring import calculate_scores
+from .utils import ensure_dir, is_weekend, nyc_now, save_json, setup_logger
+
+
+class DailyReportRunner:
+    """Main orchestration class."""
+
+    def __init__(
+        self,
+        config: AppConfig,
+        notion_service: NotionService,
+        provider: MarketDataProvider,
+        run_root: str | Path = "runs",
+    ) -> None:
+        self.config = config
+        self.notion_service = notion_service
+        self.provider = provider
+        self.logger = setup_logger(__name__)
+        self.run_root = Path(run_root)
+
+    def run(self, run_date: date | None = None, dry_run: bool = False) -> RunMetadata:
+        if run_date is None:
+            run_date = nyc_now().date()
+        market_status, is_open = self._market_status(run_date)
+        self.logger.info("Running screen for %s – Market status: %s", run_date, market_status)
+
+        if not is_open:
+            self.logger.info("Market closed – writing placeholder page")
+            metadata = RunMetadata(
+                run_datetime=nyc_now(),
+                market_status=market_status,
+                universe_size=0,
+                considered=0,
+                passed_filters=0,
+                expanded_criteria_used=False,
+                data_source=self.config.data_source.get("provider", "unknown"),
+                api_warnings=["Market closed"],
+            )
+            payload = self.notion_service.build_placeholder_page(run_date, metadata)
+            self.notion_service.dispatch(payload, dry_run=dry_run)
+            return metadata
+
+        primary_candidates = self.provider.load_candidates(run_date, expanded=False)
+        self.logger.info("Loaded %s raw candidates", len(primary_candidates))
+
+        processed_primary = self._process_candidates(primary_candidates, run_date, expanded=False)
+        triggered_count = len(processed_primary["triggered"])
+        self.logger.info("Candidates triggering drop condition: %s", triggered_count)
+
+        passed_candidates = list(processed_primary["passed"])
+        expanded_used = False
+        if len(passed_candidates) < self.config.execution.get("min_candidates_before_expand", 5):
+            self.logger.info("Expanding criteria due to insufficient candidates")
+            expanded_candidates = self.provider.load_candidates(run_date, expanded=True)
+            processed_expanded = self._process_candidates(expanded_candidates, run_date, expanded=True)
+            expanded_used = True
+            passed_candidates.extend(processed_expanded["passed"])
+            self._merge_rejections(processed_primary["rejections"], processed_expanded["rejections"])
+            processed_primary["triggered"].extend(processed_expanded["triggered"])
+
+        scores = calculate_scores(
+            [candidate.metrics for candidate in processed_primary["triggered"]],
+            self.config.scores,
+            run_date,
+        )
+        for result in processed_primary["triggered"]:
+            result.score = scores.get(result.metrics.ticker, result.score)
+
+        final_candidates = self._rank_and_cap(passed_candidates)
+        self.logger.info("Final candidate count after sector caps: %s", len(final_candidates))
+
+        charts_dir = ensure_dir(self.config.execution.get("chart_dir", "charts"))
+        for candidate in final_candidates:
+            chart_path = generate_price_chart(
+                candidate.metrics.ticker,
+                candidate.metrics.price_history_5y,
+                charts_dir,
+            )
+            candidate.metrics.chart_path = str(chart_path)
+
+        for candidate in final_candidates:
+            candidate.metrics.notes.append(build_background_blurb(candidate.metrics, run_date))
+
+        rules_block = self._build_rules_block()
+        run_metadata = RunMetadata(
+            run_datetime=nyc_now(),
+            market_status=market_status,
+            universe_size=len(primary_candidates),
+            considered=len(processed_primary["triggered"]),
+            passed_filters=len(final_candidates),
+            expanded_criteria_used=expanded_used,
+            data_source=self.config.data_source.get("provider", "unknown"),
+            api_warnings=[],
+        )
+
+        run_log = self._build_run_log(
+            run_date,
+            processed_primary,
+            final_candidates,
+            run_metadata,
+        )
+        log_path = self._write_run_log(run_date, run_log)
+        run_metadata.run_log_path = str(log_path)
+
+        summary_payload = self.notion_service.build_report_payload(
+            run_date=run_date,
+            candidates=final_candidates,
+            all_candidates=processed_primary["triggered"],
+            metadata=run_metadata,
+            rules_block=rules_block,
+            expanded=expanded_used,
+        )
+        self.notion_service.dispatch(summary_payload, dry_run=dry_run)
+        return run_metadata
+
+    def _process_candidates(
+        self,
+        metrics_list: List[CandidateMetrics],
+        run_date: date,
+        expanded: bool,
+    ) -> Dict[str, Any]:
+        triggered: List[CandidateResult] = []
+        passed: List[CandidateResult] = []
+        rejections: Dict[str, Dict[str, int]] = {"universe": {}, "filters": {}}
+
+        universe_limits = self.config.universe
+        filter_config = self.config.filters
+
+        for metrics in metrics_list:
+            is_triggered, trigger_name, reasons = determine_drop_trigger(metrics, expanded)
+            if not is_triggered:
+                continue
+            metrics.trigger = trigger_name
+            metrics.triggered_conditions = reasons
+
+            universe_ok, universe_reasons = self._passes_universe(metrics, universe_limits)
+            if not universe_ok:
+                for reason in universe_reasons:
+                    rejections.setdefault("universe", {}).setdefault(reason, 0)
+                    rejections["universe"][reason] += 1
+                continue
+
+            filter_result = passes_value_filters(metrics, filter_config, run_date)
+            candidate = CandidateResult(
+                metrics=metrics,
+                filter_result=filter_result,
+                score=ScoreBreakdown(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            )
+            triggered.append(candidate)
+
+            if not filter_result.passed:
+                for reason in filter_result.reasons:
+                    rejections.setdefault("filters", {}).setdefault(reason, 0)
+                    rejections["filters"][reason] += 1
+                continue
+            passed.append(candidate)
+        return {"triggered": triggered, "passed": passed, "rejections": rejections}
+
+    def _passes_universe(
+        self, metrics: CandidateMetrics, config: Dict[str, Any]
+    ) -> Tuple[bool, List[str]]:
+        reasons: List[str] = []
+        if metrics.price < config.get("min_price", 3.0):
+            reasons.append("Price below minimum")
+        if metrics.market_cap < config.get("min_market_cap", 0):
+            reasons.append("Market cap below minimum")
+        if metrics.avg_dollar_volume < config.get("min_adv_usd", 0):
+            reasons.append("Liquidity below threshold")
+        if any(keyword.lower() in metrics.company_name.lower() for keyword in config.get("excluded_keywords", [])):
+            reasons.append("Excluded keyword match")
+        if metrics.trading_halted:
+            reasons.append("Trading halted")
+        return len(reasons) == 0, reasons
+
+    def _rank_and_cap(self, candidates: List[CandidateResult]) -> List[CandidateResult]:
+        max_total = self.config.universe.get("max_total_candidates", 25)
+        max_sector = self.config.universe.get("max_per_sector", 5)
+        unique: Dict[str, CandidateResult] = {}
+        for candidate in candidates:
+            unique[candidate.metrics.ticker] = candidate
+        sorted_candidates = sorted(
+            unique.values(),
+            key=lambda result: result.score.total,
+            reverse=True,
+        )
+        sector_counts: Dict[str, int] = {}
+        final: List[CandidateResult] = []
+        for result in sorted_candidates:
+            if len(final) >= max_total:
+                break
+            sector = result.metrics.sector
+            count = sector_counts.get(sector, 0)
+            if count >= max_sector:
+                continue
+            sector_counts[sector] = count + 1
+            final.append(result)
+        for idx, result in enumerate(final[: self.config.execution.get("max_candidates", 12)], start=1):
+            result.rank = idx
+        return final[: self.config.execution.get("max_candidates", 12)]
+
+    def _market_status(self, run_date: date) -> Tuple[str, bool]:
+        if is_weekend(run_date):
+            return "Closed (Weekend)", False
+        try:
+            import pandas_market_calendars as mcal  # type: ignore
+
+            calendar = mcal.get_calendar("XNYS")
+            schedule = calendar.schedule(run_date, run_date)
+            if schedule.empty:
+                return "Closed (Holiday)", False
+        except Exception:  # pragma: no cover - fallback when library missing
+            self.logger.debug("pandas_market_calendars unavailable; assuming open weekday")
+        return "Open", True
+
+    def _build_rules_block(self) -> List[str]:
+        return [
+            "Max position 2% of portfolio per name.",
+            "Max 20% sector exposure from this screen.",
+            "Entry plan: scale in thirds over 10 trading days if price closes above the prior day low.",
+            "Exit plan: hard stop at −15% from average entry, time stop at 90 trading days if thesis not validated.",
+            "Disable names with pending binary events (biotech FDA dates, litigation, going-concern).",
+            "Avoid if liquidity < $5M ADV or spread > 60 bps.",
+        ]
+
+    def _build_run_log(
+        self,
+        run_date: date,
+        processed: Dict[str, List[CandidateResult]],
+        final_candidates: List[CandidateResult],
+        metadata: RunMetadata,
+    ) -> Dict[str, Any]:
+        return {
+            "run_date": run_date.isoformat(),
+            "metadata": asdict(metadata),
+            "triggered": [self._serialize_candidate(result) for result in processed["triggered"]],
+            "final": [self._serialize_candidate(result) for result in final_candidates],
+            "rejections": processed["rejections"],
+        }
+
+    def _serialize_candidate(self, result: CandidateResult) -> Dict[str, Any]:
+        return {
+            "ticker": result.metrics.ticker,
+            "company": result.metrics.company_name,
+            "sector": result.metrics.sector,
+            "score": result.score.total,
+            "trigger": result.metrics.trigger,
+            "filter_passed": result.filter_result.passed,
+            "filter_reasons": result.filter_result.reasons,
+        }
+
+    def _write_run_log(self, run_date: date, log_data: Dict[str, Any]) -> Path:
+        ensure_dir(self.run_root)
+        path = self.run_root / f"{run_date.isoformat()}.json"
+        save_json(path, log_data)
+        return path
+
+    def _merge_rejections(
+        self, base: Dict[str, Dict[str, int]], incoming: Dict[str, Dict[str, int]]
+    ) -> None:
+        for bucket, values in incoming.items():
+            for reason, count in values.items():
+                base.setdefault(bucket, {}).setdefault(reason, 0)
+                base[bucket][reason] += count
+
+
+def create_runner(config: AppConfig, env: Dict[str, str]) -> DailyReportRunner:
+    provider_config = ProviderConfig(
+        base_url=config.data_source.get("base_url", ""),
+        api_key=env.get("DATA_API_KEY"),
+        max_retries=int(config.data_source.get("max_retries", 5)),
+        backoff_seconds=int(config.data_source.get("backoff_seconds", 1)),
+        cache_ttl_seconds=int(config.data_source.get("cache_ttl_seconds", 900)),
+    )
+    provider = MarketDataProvider(provider_config)
+    notion_service = NotionService(
+        token=env.get("NOTION_API_KEY"),
+        database_id=env.get("NOTION_DATABASE_ID"),
+    )
+    return DailyReportRunner(config=config, notion_service=notion_service, provider=provider)

--- a/value_stocks/scoring.py
+++ b/value_stocks/scoring.py
@@ -1,0 +1,281 @@
+"""Composite scoring logic."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import math
+
+from .models import CandidateMetrics, ScoreBreakdown
+
+
+@dataclass
+class MetricDefinition:
+    key: str
+    weight: float
+    higher_is_better: bool = True
+    cap: float | None = None
+    floor: float | None = None
+    clip_range: Tuple[float, float] | None = None
+    transform: Optional[Callable[[CandidateMetrics], Optional[float]]] = None
+
+
+def _extract(
+    values: Iterable[CandidateMetrics],
+    attribute: str,
+    transform: Optional[Callable[[CandidateMetrics], Optional[float]]] = None,
+) -> List[float]:
+    extracted: List[float] = []
+    for metrics in values:
+        if transform is not None:
+            value = transform(metrics)
+        else:
+            value = getattr(metrics, attribute)
+        if value is None:
+            continue
+        extracted.append(float(value))
+    return extracted
+
+
+def _normalize(values: List[float], higher_is_better: bool = True) -> Dict[float, float]:
+    if not values:
+        return {}
+    unique_values = sorted(set(values))
+    if not higher_is_better:
+        unique_values = list(reversed(unique_values))
+    if len(unique_values) == 1:
+        return {unique_values[0]: 1.0}
+    max_rank = len(unique_values) - 1
+    mapping: Dict[float, float] = {}
+    for rank, value in enumerate(unique_values):
+        mapping[value] = rank / max_rank
+    # Duplicate values receive the same score
+    for value in values:
+        if value not in mapping:
+            mapping[value] = 0.0
+    return mapping
+
+
+def _score_metric(
+    metrics: CandidateMetrics,
+    definition: MetricDefinition,
+    normalization_map: Dict[float, float],
+) -> float:
+    if definition.transform is not None:
+        raw_value = definition.transform(metrics)
+    else:
+        raw_value = getattr(metrics, definition.key)
+    if raw_value is None:
+        return 0.0
+    value = float(raw_value)
+    if definition.clip_range is not None:
+        lo, hi = definition.clip_range
+        if value < lo:
+            value = lo
+        if value > hi:
+            value = hi
+    if definition.cap is not None:
+        value = min(value, definition.cap)
+    if definition.floor is not None:
+        value = max(value, definition.floor)
+    if not normalization_map:
+        return 0.0
+    score = normalization_map.get(value)
+    if score is None:
+        closest = min(normalization_map.keys(), key=lambda x: abs(x - value))
+        score = normalization_map[closest]
+    return score * definition.weight
+
+
+def calculate_scores(
+    candidates: List[CandidateMetrics],
+    config: Dict[str, Dict[str, float]],
+    run_date: date,
+) -> Dict[str, ScoreBreakdown]:
+    """Compute composite scores."""
+
+    valuation_defs = [
+        MetricDefinition("free_cash_flow_yield", config["valuation"].get("fcf_yield_weight", 15)),
+        MetricDefinition(
+            "ev_to_ebitda",
+            config["valuation"].get("ev_to_ebitda_weight", 10),
+            higher_is_better=False,
+        ),
+        MetricDefinition(
+            "pb_ratio",
+            config["valuation"].get("price_to_book_weight", 5),
+            higher_is_better=False,
+        ),
+    ]
+    quality_defs = [
+        MetricDefinition("roic", config["quality"].get("roic_weight", 10)),
+        MetricDefinition(
+            "gross_margin_stability",
+            config["quality"].get("gross_margin_stability_weight", 5),
+            higher_is_better=False,
+        ),
+        MetricDefinition(
+            "revenue_cagr_3y",
+            config["quality"].get("revenue_cagr_weight", 5),
+            clip_range=(0, 0.30),
+        ),
+    ]
+    momentum_defs = [
+        MetricDefinition(
+            "rsi_14",
+            config["momentum"].get("rsi_weight", 10),
+            higher_is_better=False,
+        ),
+        MetricDefinition(
+            "percent_to_200dma",
+            config["momentum"].get("distance_to_200dma_weight", 5),
+            higher_is_better=False,
+            cap=0.60,
+        ),
+    ]
+    risk_defs = [
+        MetricDefinition(
+            "beta",
+            config["risk"].get("beta_weight", 10),
+        ),
+        MetricDefinition(
+            "realized_vol_30d",
+            config["risk"].get("volatility_weight", 5),
+            higher_is_better=False,
+        ),
+    ]
+    liquidity_defs = [
+        MetricDefinition("avg_dollar_volume", config["liquidity"].get("dollar_volume_weight", 5)),
+        MetricDefinition(
+            "short_interest_percent",
+            config["liquidity"].get("short_interest_weight", 5),
+            transform=lambda m: short_interest_adjustment(m.short_interest_percent)
+            if m.short_interest_percent is not None
+            else None,
+        ),
+    ]
+
+    def build_norm_map(defs: List[MetricDefinition]) -> Dict[str, Dict[float, float]]:
+        maps: Dict[str, Dict[float, float]] = {}
+        for definition in defs:
+            values = _extract(candidates, definition.key, definition.transform)
+            if not values:
+                maps[definition.key] = {}
+                continue
+            maps[definition.key] = _normalize(values, definition.higher_is_better)
+        return maps
+
+    valuation_map = build_norm_map(valuation_defs)
+    quality_map = build_norm_map(quality_defs)
+    momentum_map = build_norm_map(momentum_defs)
+    risk_map = build_norm_map(risk_defs)
+    liquidity_map = build_norm_map(liquidity_defs)
+
+    scores: Dict[str, ScoreBreakdown] = {}
+    penalties_cfg = config.get("penalties", {})
+    valuation_max = sum(definition.weight for definition in valuation_defs)
+    quality_max = sum(definition.weight for definition in quality_defs)
+    momentum_max = sum(definition.weight for definition in momentum_defs)
+    risk_max = config.get("risk", {}).get("beta_weight", 10.0)
+    risk_max += sum(
+        definition.weight for definition in risk_defs if definition.key != "beta"
+    )
+    liquidity_max = sum(definition.weight for definition in liquidity_defs)
+    max_core = valuation_max + quality_max + momentum_max + risk_max + liquidity_max
+    for metrics in candidates:
+        valuation_score = sum(
+            _score_metric(metrics, definition, valuation_map.get(definition.key, {}))
+            for definition in valuation_defs
+            if metrics.ev_to_ebitda is not None or definition.key != "ev_to_ebitda"
+        )
+        quality_score = sum(
+            _score_metric(metrics, definition, quality_map.get(definition.key, {}))
+            for definition in quality_defs
+        )
+        momentum_score = sum(
+            _score_metric(metrics, definition, momentum_map.get(definition.key, {}))
+            for definition in momentum_defs
+        )
+        risk_score = _beta_band_score(metrics, config.get("risk", {}))
+        risk_score += sum(
+            _score_metric(metrics, definition, risk_map.get(definition.key, {}))
+            for definition in risk_defs
+            if definition.key != "beta"
+        )
+        liquidity_score = sum(
+            _score_metric(metrics, definition, liquidity_map.get(definition.key, {}))
+            for definition in liquidity_defs
+        )
+        penalty_score = _event_penalties(metrics, penalties_cfg, run_date)
+        core_score = (
+            valuation_score + quality_score + momentum_score + risk_score + liquidity_score
+        )
+        normalized_core = (core_score / max_core) * 100 if max_core else 0.0
+        total = max(0.0, min(100.0, normalized_core + penalty_score))
+        normalized_inputs = {
+            "fcf_yield": getattr(metrics, "free_cash_flow_yield"),
+            "ev_to_ebitda": getattr(metrics, "ev_to_ebitda"),
+            "pb_ratio": getattr(metrics, "pb_ratio"),
+            "roic": getattr(metrics, "roic"),
+            "gross_margin_stability": getattr(metrics, "gross_margin_stability"),
+            "revenue_cagr_3y": getattr(metrics, "revenue_cagr_3y"),
+            "rsi_14": getattr(metrics, "rsi_14"),
+            "percent_to_200dma": getattr(metrics, "percent_to_200dma"),
+            "beta": getattr(metrics, "beta"),
+            "realized_vol_30d": getattr(metrics, "realized_vol_30d"),
+            "avg_dollar_volume": getattr(metrics, "avg_dollar_volume"),
+            "short_interest_percent": getattr(metrics, "short_interest_percent"),
+            "short_interest_adj": short_interest_adjustment(
+                metrics.short_interest_percent or 0.0
+            ),
+            "penalty": penalty_score,
+        }
+        scores[metrics.ticker] = ScoreBreakdown(
+            total=round(total, 2),
+            valuation=round((valuation_score / max_core) * 100, 2) if max_core else 0.0,
+            quality=round((quality_score / max_core) * 100, 2) if max_core else 0.0,
+            momentum=round((momentum_score / max_core) * 100, 2) if max_core else 0.0,
+            risk=round((risk_score / max_core) * 100, 2) if max_core else 0.0,
+            liquidity=round((liquidity_score / max_core) * 100, 2) if max_core else 0.0,
+            penalties=round(penalty_score, 2),
+            normalized_inputs=normalized_inputs,
+        )
+    return scores
+
+
+def _beta_band_score(metrics: CandidateMetrics, config: Dict[str, float]) -> float:
+    center = config.get("beta_band_center", 1.0)
+    halfwidth = config.get("beta_band_halfwidth", 0.4)
+    weight = config.get("beta_weight", 10.0)
+    if metrics.beta is None:
+        return 0.0
+    distance = abs(metrics.beta - center)
+    score = max(0.0, (halfwidth - distance) / halfwidth)
+    return score * weight
+
+
+def _event_penalties(metrics: CandidateMetrics, config: Dict[str, float], run_date: date) -> float:
+    score = 0.0
+    earnings_weight = config.get("earnings_weight", 10.0)
+    if metrics.earnings_date is not None:
+        delta = (metrics.earnings_date - run_date).days
+        if abs(delta) <= 10:
+            score -= earnings_weight
+    if metrics.headline_flags:
+        score -= config.get("headline_weight", 25.0)
+    if metrics.sec_delinquent:
+        score -= config.get("sec_delinquency_weight", 40.0)
+    if metrics.going_concern:
+        score -= config.get("going_concern_weight", 60.0)
+    return score
+
+
+def short_interest_adjustment(value: float) -> float:
+    """Bell-curve style preference for 2-10% short interest."""
+    if value <= 0:
+        return 0.0
+    mean = 0.06
+    sigma = 0.03
+    exponent = -((value - mean) ** 2) / (2 * sigma**2)
+    return math.exp(exponent)

--- a/value_stocks/utils.py
+++ b/value_stocks/utils.py
@@ -1,0 +1,114 @@
+"""Utility helpers."""
+from __future__ import annotations
+
+import functools
+import json
+import logging
+import random
+import time
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, TypeVar
+
+from zoneinfo import ZoneInfo
+
+T = TypeVar("T")
+
+
+def setup_logger(name: str = "value_stocks") -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+
+
+def retry_with_backoff(
+    retries: int = 5,
+    base_delay: float = 1.0,
+    jitter: float = 0.25,
+    allowed_exceptions: Tuple[type[Exception], ...] = (Exception,),
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Simple retry decorator with exponential backoff and jitter."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            attempt = 0
+            delay = base_delay
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except allowed_exceptions:
+                    attempt += 1
+                    if attempt > retries:
+                        raise
+                    sleep_for = delay + random.uniform(0, jitter)
+                    time.sleep(sleep_for)
+                    delay *= 2
+        return wrapper
+
+    return decorator
+
+
+def in_memory_cache(ttl_seconds: int = 900) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Cache decorator for pure functions within a run."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        cache: Dict[str, Tuple[float, T]] = {}
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            key = json.dumps([args, kwargs], sort_keys=True, default=str)
+            now = time.time()
+            if key in cache:
+                ts, value = cache[key]
+                if now - ts <= ttl_seconds:
+                    return value
+            value = func(*args, **kwargs)
+            cache[key] = (now, value)
+            return value
+
+        return wrapper
+
+    return decorator
+
+
+def ensure_dir(path: str | Path) -> Path:
+    path_obj = Path(path)
+    path_obj.mkdir(parents=True, exist_ok=True)
+    return path_obj
+
+
+def nyc_now(tz_name: str = "America/New_York") -> datetime:
+    return datetime.now(ZoneInfo(tz_name))
+
+
+def format_percent(value: Optional[float], digits: int = 2) -> str:
+    if value is None:
+        return "N/A"
+    return f"{value * 100:.{digits}f}%"
+
+
+def trading_day_for(date_input: datetime, tz_name: str = "America/New_York") -> date:
+    local_date = date_input.astimezone(ZoneInfo(tz_name)).date()
+    return local_date
+
+
+def is_weekend(check_date: date) -> bool:
+    return check_date.weekday() >= 5
+
+
+def save_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, default=str)
+
+
+def date_range(start: date, end: date) -> Iterable[date]:
+    delta = end - start
+    for i in range(delta.days + 1):
+        yield start + timedelta(days=i)


### PR DESCRIPTION
## Summary
- implement the Polygon-backed data pipeline that fetches aggregates, fundamentals, news, and earnings for triggered tickers
- add reusable analytics helpers for price-based indicators, risk stats, and historical medians used throughout the report
- extend price history points with volume so liquidity and volatility metrics can be computed from vendor data

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbf1bff3ec832091ba7c823f30adc5